### PR TITLE
fix: typo in await req.json()

### DIFF
--- a/frameworks/next-js-files.mdx
+++ b/frameworks/next-js-files.mdx
@@ -308,7 +308,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest, res: NextResponse) {
   try {
-    const data = await reqest.json()
+    const data = await req.json()
     const url = await pinata.gateways.createSignedURL({
         cid: data.cid,
         expires: 30


### PR DESCRIPTION
looks like a typo 'reqest' was copied over.