### PR TITLE
Update node-js.mdx to handle proper fetch, previous one was causing a…

### DIFF
--- a/frameworks/node-js.mdx
+++ b/frameworks/node-js.mdx
@@ -144,7 +144,7 @@ const pinata = new PinataSDK({
 
 async function main() {
   try {
-    const file = await pinata.gateways.get("bafkreiac3t35fklpiwqonav2vj4x2dh6x2zugkdu7dsh6zkaq5jr33lcwy")
+    const file = await pinata.gateways.public.get("bafkreiac3t35fklpiwqonav2vj4x2dh6x2zugkdu7dsh6zkaq5jr33lcwy")
     console.log(file.data)
   } catch (error) {
     console.log(error);


### PR DESCRIPTION


The current of the version provides the following code to fetch data 
```
    const file = await pinata.gateways.get("bafkreiac3t35fklpiwqonav2vj4x2dh6x2zugkdu7dsh6zkaq5jr33lcwy")
```

but, `pinata.gateways.get()` is not a valid function and it should be `pinata.gateways.public.get("CID_URL")`. The curent versions throws the following eror 
![Screenshot From 2025-06-18 21-02-17](https://github.com/user-attachments/assets/f90d17a6-6db1-4ab5-9654-1ced8a913148)



 