### PR TITLE
fix: pivate -> private typo in files/private/list

### DIFF
--- a/sdk/files/private/list.mdx
+++ b/sdk/files/private/list.mdx
@@ -15,7 +15,7 @@ const pinata = new PinataSDK({
   pinataGateway: "example-gateway.mypinata.cloud",
 });
 
-const files = await pinata.files.pivate.list()
+const files = await pinata.files.private.list()
 ```
 
 ## Returns


### PR DESCRIPTION
### Note to Reviewers 
Hi Reviewers,

I was going through the Pinata Docs for private JSON data upload and retrieval, and spotted this small typo. Yes, I'm aware that this may count as one of the "unhelpful" edits, but the type is too painful to keep looking at.

Thanks.

### Screenshots

![image](https://github.com/user-attachments/assets/90209a83-a95c-43a1-a3b0-095ed81e6215)


- [x] Yes, I've signed my commits