### PR TITLE
Discrepancy between documentation and API reference in query name

### DIFF
--- a/pinata-api-v3.yaml
+++ b/pinata-api-v3.yaml
@@ -2225,7 +2225,7 @@ paths:
             type: boolean
           description: Return only files that are still waiting for a CID
           example: "true"
-        - name: metadata
+        - name: keyvalues
           in: query
           style: deepObject
           explode: true


### PR DESCRIPTION
In the general documentation, the field name for filtering files by metadata is "keyvalues", while in the API reference, its "metadata". 
const url = "https://api.pinata.cloud/v3/files/public?keyvalues[env]=prod"