### PR TITLE
Refresh agent docs for v0.11.1 API and UI

### DIFF
--- a/agents/api.mdx
+++ b/agents/api.mdx
@@ -1,0 +1,400 @@
+---
+title: "HTTP API"
+sidebarTitle: "HTTP API"
+description: "Authenticate, manage agents, and talk to gateways over HTTP"
+icon: "plug"
+---
+
+The Agents API is the same API the dashboard uses. Everything in the UI is exposed at `agents.pinata.cloud` - including agent management, secrets, skills, channels, snapshots, custom domains, devices, and OpenClaw config.
+
+Full OpenAPI reference: [agents.pinata.cloud/openapi](https://agents.pinata.cloud/openapi) (also linked from the Support → OpenAPI Docs item in the sidebar).
+
+## Base URLs
+
+There are two surfaces, on purpose:
+
+| Surface | Host | Auth | What it's for |
+| --- | --- | --- | --- |
+| **Management** | `agents.pinata.cloud` | Pinata JWT | Creating agents, managing secrets, browsing templates |
+| **Per-agent** | `{agentId}.agents.pinata.cloud` | Gateway token | Talking to a specific agent (chat, routes, files, devices) |
+
+The same agent sub-routes (`/v0/agents/{agentId}/...`) are mounted on both. Use the management host when you have the workspace owner's JWT; use the per-agent host when you only have the gateway token.
+
+## Authentication
+
+Three credentials, used in different contexts:
+
+### Pinata JWT
+
+Standard Pinata API key (`bearerAuth` in the OpenAPI spec). Used for all management routes (`/v0/agents`, `/v0/secrets`, `/v0/skills`, `/v0/templates`, etc.).
+
+```http
+Authorization: Bearer <PINATA_JWT>
+```
+
+Create one in your [Account → API Keys](/account-management/api-keys).
+
+### Gateway token
+
+Per-agent token (`gatewayToken` in the OpenAPI spec) used for the agent's own subdomain. Read it from the agent's **Danger** page or `GET /v0/agents/{agentId}/gateway-token`. Rotate it from the same page or `POST /v0/agents/{agentId}/gateway-token/rotate`.
+
+Passing the gateway token:
+
+```http
+Authorization: Bearer <GATEWAY_TOKEN>
+```
+
+```http
+?token=<GATEWAY_TOKEN>
+```
+
+```http
+Cookie: gw_token=<GATEWAY_TOKEN>
+```
+
+<Warning>
+  The gateway token grants full access to the agent's container - console, files, routes, everything. Treat it like a server credential.
+</Warning>
+
+### Git Basic auth
+
+Used only by the Git Smart HTTP endpoints (`/v0/agents/{agentId}/git/...`). Sent as HTTP Basic auth - username is ignored, password is the gateway token. The **Copy with Token** button on the Files tab embeds this for you.
+
+### Platform JWT (for skills)
+
+Inside an agent, the `@pinata/platform` skill can exchange the gateway token for a short-lived (1 hour) platform JWT. That JWT then unlocks the management-domain API (create secrets, install skills, etc.) on the agent's behalf - so an agent can self-modify without ever seeing the user's Pinata JWT.
+
+```bash
+# From inside the agent container:
+curl -X POST \
+  -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" \
+  https://{agentId}.agents.pinata.cloud/v0/platform/token
+```
+
+## Quick Examples
+
+All examples below use `PINATA_JWT` (from `https://app.pinata.cloud`) or `GATEWAY_TOKEN` (from the agent's Danger page).
+
+### List your agents
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents
+```
+
+### Create an agent
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Agent",
+    "description": "Personal assistant",
+    "emoji": "🤖",
+    "skillCids": ["@pinata/api"],
+    "secretIds": ["secret-id-1"]
+  }' \
+  https://agents.pinata.cloud/v0/agents
+```
+
+Returns `201` with the created agent. Returns `403` if you're at the agent limit.
+
+### Get agent details
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID
+```
+
+Response includes `agent`, `processStatus`, `skills`, `secrets`, `snapshots`, and `portForwarding`.
+
+### Restart the gateway
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/restart
+```
+
+### Run a shell command
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"command":"ls workspace","cwd":"/home/node/clawd"}' \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/console/exec
+```
+
+Returns `{ stdout, stderr, exitCode, command, timestamp }`.
+
+### Read a file
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  "https://agents.pinata.cloud/v0/agents/$AGENT_ID/files?path=workspace/IDENTITY.md"
+```
+
+### Upload a file
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d "{\"filename\":\"report.pdf\",\"contentBase64\":\"$(base64 -w0 < report.pdf)\"}" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/files/upload
+```
+
+Returns `{ path, filename, size }`. File limit matches the read endpoint (a few MB).
+
+### Snapshot now
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/snapshots/sync
+```
+
+### Reset to a snapshot
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"snapshotCid":"QmXyz..."}' \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/snapshots/reset
+```
+
+### Read the latest logs
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/logs
+```
+
+Returns the last 100 lines as a single string.
+
+### Validate manifest / config
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d "{\"config\":$(jq -Rs . < manifest.json)}" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/config/validate
+```
+
+## Files
+
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/v0/agents/{agentId}/files?path=<path>` | `GET` | Read any file from the container |
+| `/v0/agents/{agentId}/files/upload` | `POST` | Upload a base64 file into `<workspace>/uploads/` (max ~few MB, `413` if too large) |
+| `/v0/agents/{agentId}/snapshots` | `GET` | Latest 10 snapshots |
+| `/v0/agents/{agentId}/snapshots/sync` | `GET` / `POST` | Get sync status / take a snapshot now |
+| `/v0/agents/{agentId}/snapshots/reset` | `POST` | Reset to a specific snapshot CID |
+
+## Custom Domains
+
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/v0/agents/{agentId}/domains` | `GET` | List subdomains and custom domains |
+| `/v0/agents/{agentId}/domains` | `POST` | Register a subdomain or custom domain |
+| `/v0/agents/{agentId}/domains/challenge` | `POST` | Get the TXT verification value for a custom domain |
+| `/v0/agents/{agentId}/domains/{domainId}` | `PUT` / `DELETE` | Update port/protected or remove |
+| `/v0/agents/{agentId}/domains/{domainId}/verify` | `POST` | Verify ownership and provision SSL |
+
+See [Routes & Domains](/agents/routes) for the full workflow.
+
+## Devices
+
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/v0/agents/{agentId}/devices` | `GET` | List pending and paired devices |
+| `/v0/agents/{agentId}/devices/{requestId}/approve` | `POST` | Approve a specific device |
+| `/v0/agents/{agentId}/devices/approve-all` | `POST` | Bulk-approve every pending device |
+
+## Streaming logs
+
+The Logs tab streams over WebSocket on the agent's subdomain:
+
+```
+wss://{agentId}.agents.pinata.cloud/v0/logs?token=<GATEWAY_TOKEN>
+```
+
+Each message is a JSON object: `{ timestamp, level, source, message }`. Filter on the client by `level` (`TRACE` ... `FATAL`) and free-text on `message`.
+
+## Error Format
+
+Errors return JSON with a single `error` field:
+
+```json
+{ "error": "Validation failed: skills exceeds maximum of 10" }
+```
+
+Status codes follow HTTP semantics - `400` for validation, `401` for missing auth, `403` for plan/permission issues, `404` for missing resources, `409` for conflicts (duplicate secret name, both subdomain and customDomain provided, etc.), `413` for upload size, `500` for internal failures, `503` when an upstream (Convex, Pinata storage) is unreachable.
+
+See [Errors](/agents/errors) for the full code-by-code reference.
+
+## Endpoint Quick Reference
+
+Compact index of every endpoint, grouped by purpose. `JWT` = Pinata JWT, `GW` = gateway token (per-agent host). All paths under `agents.pinata.cloud`.
+
+### Agents
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents` | JWT | List your agents |
+| `POST` | `/v0/agents` | JWT | Create an agent |
+| `GET` | `/v0/agents/{agentId}` | JWT / GW | Agent detail (skills, secrets, snapshots, routes) |
+| `DELETE` | `/v0/agents/{agentId}` | JWT | Delete the agent |
+| `POST` | `/v0/agents/{agentId}/restart` | JWT / GW | Restart the gateway |
+| `GET` | `/v0/agents/{agentId}/logs` | JWT / GW | Last 100 log lines |
+| `GET` | `/v0/agents/engines` | JWT | List available engines (`openclaw`, `hermes`) |
+| `GET` | `/v0/agents/{agentId}/available-agent-versions` | JWT / GW | Versions you can upgrade to |
+| `POST` | `/v0/agents/{agentId}/scripts/retry` | JWT / GW | Re-run `build` then `start` |
+| `GET` | `/v0/agents/{agentId}/update` | JWT / GW | Check for OpenClaw updates |
+| `POST` | `/v0/agents/{agentId}/update` | JWT / GW | Apply an OpenClaw update |
+
+### Auth
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/gateway-token` | JWT | Get the current gateway token |
+| `POST` | `/v0/agents/{agentId}/gateway-token/rotate` | JWT | Rotate it |
+| `POST` | `/v0/agents/{agentId}/platform/token` | GW | Exchange gateway token for a 1h platform JWT |
+| `GET` | `/v0/agents/{agentId}/platform/whoami` | GW | Agent's own identity |
+
+### Secrets
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/secrets` | JWT | List your secrets |
+| `POST` | `/v0/secrets` | JWT | Create a secret |
+| `PUT` | `/v0/secrets/{id}` | JWT | Update value |
+| `DELETE` | `/v0/secrets/{id}` | JWT | Delete |
+| `POST` | `/v0/agents/{agentId}/secrets` | JWT / GW | Attach existing secrets to an agent |
+| `DELETE` | `/v0/agents/{agentId}/secrets/{secretId}` | JWT / GW | Detach a secret |
+
+### Skills
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/skills` | JWT | List your installed skills |
+| `POST` | `/v0/skills` | JWT | Register a new skill from a folder |
+| `GET` | `/v0/skills/{skillId}/versions` | JWT | List versions |
+| `POST` | `/v0/skills/{skillId}/versions` | JWT | Publish a new version |
+| `DELETE` | `/v0/skills/{skillCid}` | JWT | Remove from library |
+| `GET` | `/v0/clawhub` | JWT | Browse the community hub |
+| `GET` | `/v0/clawhub/{slug}` | JWT | Hub skill detail |
+| `POST` | `/v0/clawhub/{hubSkillId}/install` | JWT | Install a hub skill |
+| `GET` | `/v0/agents/{agentId}/skills` | JWT / GW | Skills attached to this agent |
+| `POST` | `/v0/agents/{agentId}/skills` | JWT / GW | Attach |
+| `DELETE` | `/v0/agents/{agentId}/skills/{skillId}` | JWT / GW | Detach |
+| `GET` | `/v0/agents/{agentId}/skills/updates` | JWT / GW | Check for skill updates |
+| `POST` | `/v0/agents/{agentId}/skills/{skillId}/update` | JWT / GW | Bump a skill on this agent |
+
+### Channels
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/channels` | JWT / GW | Status of all channels |
+| `POST` | `/v0/agents/{agentId}/channels/{channel}` | JWT / GW | Configure (`telegram`/`slack`/`discord`/`whatsapp`) |
+| `DELETE` | `/v0/agents/{agentId}/channels/{channel}` | JWT / GW | Remove |
+
+### Routes & domains
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/port-forwarding` | JWT / GW | List path routes |
+| `PUT` | `/v0/agents/{agentId}/port-forwarding` | JWT / GW | Replace path routes |
+| `GET` | `/v0/agents/{agentId}/domains` | JWT / GW | List domains and subdomains |
+| `POST` | `/v0/agents/{agentId}/domains` | JWT / GW | Register a subdomain or custom domain |
+| `POST` | `/v0/agents/{agentId}/domains/challenge` | JWT / GW | Get TXT challenge for a custom domain |
+| `PUT` | `/v0/agents/{agentId}/domains/{domainId}` | JWT / GW | Update port/protected |
+| `DELETE` | `/v0/agents/{agentId}/domains/{domainId}` | JWT / GW | Remove |
+| `POST` | `/v0/agents/{agentId}/domains/{domainId}/verify` | JWT / GW | Verify ownership + provision SSL |
+
+### Tasks
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/tasks` | JWT / GW | List cron jobs |
+| `POST` | `/v0/agents/{agentId}/tasks` | JWT / GW | Create |
+| `GET` | `/v0/agents/{agentId}/tasks/{jobId}` | JWT / GW | Detail |
+| `PUT` | `/v0/agents/{agentId}/tasks/{jobId}` | JWT / GW | Update |
+| `DELETE` | `/v0/agents/{agentId}/tasks/{jobId}` | JWT / GW | Delete |
+| `POST` | `/v0/agents/{agentId}/tasks/{jobId}/run` | JWT / GW | Run now |
+| `POST` | `/v0/agents/{agentId}/tasks/{jobId}/toggle` | JWT / GW | Enable / disable |
+| `GET` | `/v0/agents/{agentId}/tasks/{jobId}/runs` | JWT / GW | Run history |
+
+### Files & snapshots
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/files?path=<path>` | JWT / GW | Read a file from inside the container |
+| `POST` | `/v0/agents/{agentId}/files/upload` | JWT / GW | Upload base64 file to `<workspace>/uploads/` |
+| `GET` | `/v0/agents/{agentId}/snapshots` | JWT / GW | Last 10 snapshots |
+| `GET` | `/v0/agents/{agentId}/snapshots/sync` | JWT / GW | Sync status |
+| `POST` | `/v0/agents/{agentId}/snapshots/sync` | JWT / GW | Trigger a snapshot now |
+| `POST` | `/v0/agents/{agentId}/snapshots/reset` | JWT / GW | Reset to a snapshot CID |
+
+### Console
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `POST` | `/v0/agents/{agentId}/console/exec` | JWT / GW | Run a shell command, returns `{stdout, stderr, exitCode}` |
+
+### Devices
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/devices` | JWT / GW | List pending + paired |
+| `POST` | `/v0/agents/{agentId}/devices/{requestId}/approve` | JWT / GW | Approve one |
+| `POST` | `/v0/agents/{agentId}/devices/approve-all` | JWT / GW | Approve every pending |
+
+### Config (OpenClaw runtime)
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/config` | JWT / GW | Read `openclaw.json` |
+| `PUT` | `/v0/agents/{agentId}/config` | JWT / GW | Write `openclaw.json` (validated server-side) |
+| `POST` | `/v0/agents/{agentId}/config/validate` | JWT / GW | Validate `openclaw.json` without applying |
+
+<Note>
+  Note `config/validate` validates `openclaw.json` (runtime config), **not** `manifest.json`. To validate a manifest, use `POST /v0/templates/validate` or run `pinata agents templates validate`.
+</Note>
+
+### Templates
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/templates` | JWT | List your templates |
+| `POST` | `/v0/templates` | JWT | Submit a template from a git repo |
+| `GET` | `/v0/templates/{slug}` | JWT | Get by slug |
+| `GET` | `/v0/templates/id/{templateId}` | JWT | Get by ID |
+| `PUT` | `/v0/templates/{templateId}` | JWT | Update / resubmit |
+| `DELETE` | `/v0/templates/{templateId}` | JWT | Archive |
+| `POST` | `/v0/templates/validate` | JWT | Validate a git repo for template submission |
+| `POST` | `/v0/templates/branches` | JWT | List branches on a public repo |
+| `POST` | `/v0/templates/refs` | JWT | List branches + tags |
+| `GET` | `/v0/public-templates` | none | Public marketplace listing |
+
+### Git Smart HTTP
+
+| Method | Path | Auth | Description |
+| --- | --- | :---: | --- |
+| `GET` | `/v0/agents/{agentId}/git/info/refs` | Git Basic (GW as password) | Ref advertisement |
+| `POST` | `/v0/agents/{agentId}/git/git-upload-pack` | Git Basic (GW as password) | `git clone` / `git pull` |
+| `POST` | `/v0/agents/{agentId}/git/git-receive-pack` | Git Basic (GW as password) | `git push` |
+
+## OpenAPI Spec
+
+For everything not covered here:
+
+```
+https://agents.pinata.cloud/openapi
+```
+
+The OpenAPI spec is the authoritative source - schemas, query parameters, response codes, and per-endpoint descriptions.

--- a/agents/channels.mdx
+++ b/agents/channels.mdx
@@ -1,84 +1,92 @@
 ---
 title: "Channels"
-description: "Connect your agent to messaging platforms"
+description: "Let people talk to your agent on Telegram, Slack, or Discord"
 icon: "comments"
 ---
 
-Channels let your agent talk to people on Telegram, Slack, and Discord. Instead of everyone coming to the Pinata dashboard, they can message your agent where they already hang out.
+By default, the only way to talk to your agent is through the Pinata dashboard. Channels change that — connect Telegram, Slack, or Discord, and your agent shows up wherever you and your team already chat.
 
-**Currently available:** Telegram, Slack, Discord
-
-**Coming soon:** WhatsApp
+WhatsApp is on the roadmap; you'll see its card grayed out as **Coming Soon**.
 
 <Frame>
   ![Image](/images/image-31.png)
 </Frame>
 
+## How it works
+
+Open your agent → **Channels**. You'll see one card per platform.
+
+- A card with **+ ADD** isn't connected yet. Click it to open the setup dialog.
+- A card with **ENABLED** is already connected. The card shows a summary (the DM policy and a masked bot token), and a **RECONFIGURE** button reopens the dialog so you can update settings without losing the connection.
+
+Setup is the same shape for every platform: grab a bot token from the platform, paste it into the dialog, save. Some platforms need an extra token or an OAuth invite to a workspace/server.
+
+Once a channel is enabled, anyone who messages your bot on that platform is talking to your agent. Responses come back through the same channel.
+
 ## Telegram
 
-Telegram is the quickest to set up. You'll create a bot through Telegram's BotFather and connect it to your agent.
+This is the quickest. You need a bot token from Telegram's BotFather.
 
-1. Open Telegram and message [@BotFather](https://t.me/botfather)
-2. Send `/newbot` and follow the prompts to create your bot
+1. In Telegram, message [@BotFather](https://t.me/botfather)
+2. Send `/newbot` and follow the prompts
 3. Copy the bot token BotFather gives you
-4. In Pinata, open your agent → **Channels** and click **\+ ADD** on the Telegram card
-5. Paste your bot token and save
+4. In Pinata: agent → **Channels** → **+ ADD** on the Telegram card
+5. Paste the token and save
 
-Now anyone who messages your Telegram bot is talking to your agent.
+### Controlling who can DM your bot
 
-### Controlling Access
+The Telegram dialog has two access controls:
 
-By default, your bot is open - anyone can message it. If you want to restrict access:
+- **DM policy** — `open` (anyone can message) or `pairing` (users must be approved first)
+- **Allow list** — a list of Telegram user IDs that are allowed to message
 
-- **DM policy** - Switch from "open" to "pairing" mode, which requires users to be approved before they can chat
-- **Allow list** - Only specific Telegram user IDs can message the bot
-
-You can use either or both. Configure these in the channel settings.
+You can use either or both. Leave both at their defaults if you want anyone to be able to chat.
 
 ## Slack
 
-Slack takes a few more steps because you need to create a Slack App with the right permissions.
+Slack needs a custom app with the right permissions. It's a few more steps but everything happens once.
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
-2. Enable **Socket Mode** (under Settings)
+2. Enable **Socket Mode**
 3. Create an **App-Level Token** with the `connections:write` scope
-4. Under **OAuth & Permissions**, add these bot token scopes:
-   - `chat:write`, `im:write`, `im:history`, `im:read`, `users:read`, `app_mentions:read`
+4. Under **OAuth & Permissions**, add these bot token scopes: `chat:write`, `im:write`, `im:history`, `im:read`, `users:read`, `app_mentions:read`
 5. Install the app to your workspace
-6. In Pinata, open your agent → **Channels** and click **\+ ADD** on the Slack card
-7. Paste both tokens:
-   - **Bot Token** - starts with `xoxb-`
-   - **App Token** - starts with `xapp-`
-8. Save
+6. In Pinata: agent → **Channels** → **+ ADD** on the Slack card
+7. Paste both tokens — bot token starts with `xoxb-`, app token starts with `xapp-`
 
-Your agent will now respond to DMs and mentions in your Slack workspace.
+Once connected, the bot responds to DMs and to `@mentions` in any channel it's been invited to.
 
 ## Discord
 
-Discord setup is similar to Telegram - create a bot, get a token, connect it.
+Same shape as Telegram — make a bot in Discord's developer portal, copy the token, paste it in.
 
 1. Go to [discord.com/developers](https://discord.com/developers/applications) and create an application
-2. Go to **Bot** → **Add Bot**
-3. Copy the bot token (you may need to reset it to see it)
-4. Go to **OAuth2** → **URL Generator**
-   - Select the `bot` scope
-   - Select the permissions your bot needs
-5. Copy the generated URL and open it to invite the bot to your server
-6. In Pinata, open your agent → **Channels** and click **\+ ADD** on the Discord card
-7. Paste the bot token and save
+2. Under **Bot**, click **Add Bot** and copy the token (you may need to reset it once to reveal it)
+3. Under **OAuth2 → URL Generator**, check the `bot` scope and the permissions your bot needs
+4. Open the generated URL to invite the bot to your server
+5. In Pinata: agent → **Channels** → **+ ADD** on the Discord card
+6. Paste the bot token and save
 
-Your agent can now respond in Discord.
+## Updating or removing a channel
 
-## Managing Channels
-
-Once connected, channels show a green **ENABLED** badge along with a summary of your configuration (DM policy, masked token). You can:
-
-- **Reconfigure** to update settings (leave token fields blank to keep existing values)
+- **Reconfigure** — click **RECONFIGURE** on an enabled channel. You can leave the token fields blank to keep the existing token while changing other settings.
+- **Remove** — same dialog, **Remove** action. This deletes the channel config and restarts the agent's gateway.
 
 <Note>
-  Changes to channels take effect after a gateway restart.
+  Channel changes take effect after the gateway restarts. Configure and remove handle that automatically.
 </Note>
 
 <Warning>
-  Bot tokens are sensitive. Don't share them or commit them to version control.
+  Bot tokens are sensitive. Keep them out of source control. They're stored encrypted on Pinata's side; treat them the same way locally.
 </Warning>
+
+## When it doesn't work
+
+| Symptom | What's going on | What to do |
+| --- | --- | --- |
+| Bot doesn't respond | Gateway didn't restart after configure | Open **Danger** → **Restart Gateway** |
+| Slack works in DMs but not channels | Missing `app_mentions:read` scope | Reinstall the Slack app with the scopes above |
+| Telegram users get no reply | `dmPolicy` is `pairing` and they aren't paired yet | Switch to `open`, or approve them via [Devices](/agents/devtools#device-pairing) |
+| `403` when adding a channel | Plan limit or workspace permissions | Check your plan and workspace role |
+
+If none of these match, check [Logs](/agents/logs) for entries from `gateway/reload` and the channel name, or walk through [Troubleshooting](/agents/troubleshooting).

--- a/agents/chat.mdx
+++ b/agents/chat.mdx
@@ -4,64 +4,60 @@ description: "Talk to your agent through the web interface"
 icon: "message"
 ---
 
-The Chat page is where you interact with your agent. It's a real-time conversation interface that shows your messages, agent responses, and any tools the agent uses along the way.
+The Chat tab is your main conversation with the agent. Messages stream in real time. You see your prompts, the agent's responses, any tools it called along the way, and — if you enable it — its thinking.
 
-Open your agent → **Chat** to start talking.
+Open your agent → **Chat**.
 
 <Frame>
   ![Image](/images/image-30.png)
 </Frame>
 
-## Connection Status
+## Sending a message
 
-At the top you'll see "CONNECTED" with a green dot when your agent is ready. If the connection drops, the status updates and you can refresh to reconnect.
+The composer is at the bottom of the page.
 
-## Agent Sidebar
+- **+** opens an attachment picker. Files you attach land in `<workspace>/uploads/` inside the container, and the agent gets the path in its context.
+- The text input is the message itself. Press Enter to send, Shift+Enter for a newline.
+- **MODEL** picks which model handles this turn. It defaults to whatever you set as the agent's default — see [Models](/agents/models).
+- The send arrow submits.
 
-The right side of the chat page shows a live overview of your agent - its status, current model, version, and resource usage (CPU, memory, disk, network). You'll also see quick counts for attached skills, secrets, and tasks, plus any custom domain routes you've configured.
+## Slash commands
 
-This sidebar is a good way to keep an eye on your agent's health without leaving the conversation.
+Type `/` at the start of a message to run a command instead of a regular prompt:
 
-## Switching Models
-
-Use the model dropdown in the sidebar to switch between any models you've [enabled for this agent](/agents/models). You can switch mid-conversation - useful for:
-
-- Using a faster model for quick questions
-- Switching to a more capable model for complex reasoning
-- Comparing how different models handle the same prompt
-
-The dropdown shows models by provider (e.g., `anthropic/claude-sonnet-4-6`).
-
-## Display Settings
-
-Click the settings icon (sliders) to toggle what's visible in the chat:
-
-| Setting | What it does |
+| Command | Effect |
 | --- | --- |
-| **Markdown** | Render markdown formatting in responses |
-| **Thinking** | Show extended thinking blocks when available |
-| **Tool Calls** | Show tool use blocks (commands, API calls, etc.) |
-| **Image Preview** | Display images inline |
-| **Timestamps** | Show when each message was sent |
-| **Avatars** | Show profile pictures next to messages |
+| `/new` | Starts a fresh session — the agent forgets the prior conversation |
+| `/status` | Prints the current model, session info, and key flags |
+| `/help` | Shows the commands your agent supports |
 
-These are personal preferences - they don't affect how your agent works, just how you see the conversation.
+The list depends on your agent's OpenClaw version and any skills you've attached, so `/help` is the best way to see what's actually available.
 
-## Tool Calls
+## Reading agent responses
 
-When your agent uses a tool, you'll see it in the chat as an expandable block:
+Each turn the agent sends back has a few elements you'll see in the chat:
 
-- **Tool name** - What tool was called (e.g., `cron`, `bash`, `web_search`)
-- **Arguments** - What parameters were passed
-- **Result** - What came back
+- **Thinking block** — collapsed by default, labeled `Thinking ▾`. Click it to expand. Only appears for models that expose reasoning.
+- **Message text** — the actual reply. Renders markdown, including code blocks and tables.
+- **Tool calls** — if the agent called a tool (a shell command, a web search, a skill), you'll see a labeled block with the arguments and result. This is your single best window into *why* the agent answered the way it did.
+- **Model badge** — after the response, a small badge shows which model produced it. Useful when you've been switching models mid-conversation.
 
-Click "Show more" to expand the full details. This is helpful for debugging or understanding exactly what your agent did.
+When you want to debug a bad answer, expand the thinking block and the tool calls before anything else. That's almost always where the answer is.
 
-## Fullscreen Mode
+## Switching models mid-conversation
 
-Click the expand icon in the top-right to go fullscreen. This hides the sidebar and gives you more room for the conversation. Click again to exit.
+Use the **MODEL** dropdown in the composer. You can switch between any models you've enabled for this agent — start a turn with a cheap, fast model, then bump up for a hard question. Each turn is tagged with the model that produced it, so the conversation stays readable.
+
+If you want to confirm what the agent is currently using without scrolling, send `/status`.
+
+## More room for the conversation
+
+Click **Hide navbar** in the top-right corner to collapse the left sidebar — the conversation gets the full width of the screen. Click it again to bring the sidebar back.
 
 ## Tips
 
-- Tool calls can take a few seconds - the interface shows a progress indicator while the agent is working
-- If the agent seems stuck, try rephrasing or breaking your request into smaller steps
+- Long-running tool calls show a progress indicator. Wait for it before assuming the agent is stuck.
+- If the chat looks disconnected and stays that way, the gateway probably needs a kick. Open **Danger** → **Restart Gateway**.
+- If you change a secret, attach a new skill, or add a channel, restart the gateway so the agent picks up the change.
+
+For deeper debugging, the [Logs](/agents/logs) tab streams everything OpenClaw is doing under the hood. See [Troubleshooting](/agents/troubleshooting) for common failure modes.

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -1,0 +1,201 @@
+---
+title: "Concepts"
+description: "Terms, file layout, and how the pieces fit together"
+icon: "compass"
+---
+
+The agent platform has a handful of moving parts, and they don't always have obvious names. This page is your reference: every term, every standard file path, every reserved port. Skim it now to get the lay of the land; come back later when something in the docs reads like jargon.
+
+## The shape of things
+
+```text
+Workspace (your team)  ──►  Agent (container)  ──►  Channels / Routes / Tasks
+   │                            │
+   │                            ├─ Skills (capabilities)
+   │                            ├─ Secrets (env vars)
+   │                            ├─ Models (LLMs it can call)
+   │                            └─ Workspace files + snapshots
+   ▼
+Pinata IPFS + R2 (storage)
+```
+
+A **workspace** is a Pinata team. Inside it you create one or more **agents** — each is an isolated container running the [OpenClaw](https://openclaw.org) engine, with its own files, gateway, and per-agent subdomain.
+
+## Glossary
+
+### Agent
+
+A single isolated container with a persistent workspace, gateway, and `{agentId}.agents.pinata.cloud` subdomain. Created via `POST /v0/agents` or the Create Agent button. Identified by `agentId` (a short slug like `x0i33jye`).
+
+### Engine
+
+The runtime that powers the agent. `openclaw` is the default; `hermes` is also enumerated. Set via `engine` in [`manifest.json`](/agents/manifest).
+
+### Gateway
+
+The long-running process inside each agent container that:
+
+- Terminates WebSocket connections from the dashboard, channels, and CLI
+- Routes path/domain traffic to user-defined ports
+- Brokers HTTP API calls for the per-agent subdomain
+- Restarts on **Restart Gateway** in the [Danger](/agents/devtools) tab
+
+Listens on the reserved port `18789`.
+
+### Gateway token
+
+Per-agent credential used to authenticate against the agent's own subdomain (`{agentId}.agents.pinata.cloud/...`). See [API → Gateway token](/agents/api#gateway-token). Distinct from the **Pinata JWT** (workspace-wide API key) and from the **platform JWT** (1h token an agent gets from itself via `POST /v0/platform/token`).
+
+| Token | Where it works | What it's for |
+| --- | --- | --- |
+| Pinata JWT | `agents.pinata.cloud` | Workspace-wide management - create/list/delete agents, manage secrets, browse templates |
+| Gateway token | `{agentId}.agents.pinata.cloud` | Talk to one specific agent (chat, files, routes, console, git) |
+| Platform JWT | `agents.pinata.cloud` | A short-lived JWT the agent gets *for itself* - lets the agent self-modify via `@pinata/platform` |
+
+### Workspace
+
+Two meanings - context disambiguates:
+
+1. **Team workspace** - your Pinata account or shared team. Switch under **Account → Workspaces**.
+2. **Agent workspace** - the per-agent file tree at `/home/node/clawd/workspace/` inside the container. Includes [`manifest.json`](/agents/manifest), `SOUL.md`, attached skills under `skills/`, file uploads under `uploads/`, and anything else your agent has written.
+
+### Workspace anatomy
+
+The default file layout inside `workspace/`:
+
+| File | Purpose |
+| --- | --- |
+| `manifest.json` | Agent configuration - identity, secrets, skills, scripts, routes, channels, tasks. Single source of truth. |
+| `SOUL.md` | Agent personality and principles - customize freely |
+| `AGENTS.md` | Conventions the agent follows when working in the repo (memory system, safety rules, file layout) |
+| `IDENTITY.md` | Name, vibe, emoji, owner identity - written at deploy time |
+| `USER.md` | Notes about the human user, learned over time |
+| `TOOLS.md` | Environment notes (what tools exist in the container) |
+| `BOOTSTRAP.md` | First-run conversation guide. Self-deletes after setup. |
+| `HEARTBEAT.md` | Periodic-task notes (empty by default) |
+| `skills/<name>/` | Files for each attached skill |
+| `uploads/` | Files uploaded via the chat attachment button or `POST /v0/agents/{agentId}/files/upload` |
+
+You can commit and push anything else (`projects/`, `scripts/`, etc.) - the agent treats the whole tree as fair game.
+
+### `manifest.json` vs `openclaw.json`
+
+These are two different files. Both are JSON; they live in different places and have different schemas.
+
+| File | Path | Schema | Edited by |
+| --- | --- | --- | --- |
+| `manifest.json` | `<workspace>/manifest.json` | [`manifest.v1.json`](/agents/manifest) | You (committed to git, validated via `POST /v0/templates/validate`) |
+| `openclaw.json` | `/home/node/.openclaw/openclaw.json` | OpenClaw runtime schema | OpenClaw at runtime (validated via `POST /v0/agents/{agentId}/config/validate`) |
+
+Day-to-day, edit `manifest.json`. `openclaw.json` is the engine's runtime mirror and is generally only touched via the **OpenClaw Settings UI** on the Danger tab.
+
+### Skill
+
+A reusable package of files and instructions that extends an agent's capabilities. Pinned to IPFS, addressed by **slug** (`@pinata/api`) or **CID**. Installed into your Skills Library, then attached per-agent. Up to 10 attached per agent. See [Skills](/agents/skills).
+
+The platform ships with `@pinata/platform` bundled - it lets the agent perform self-service operations (install skills, set secrets, manage tasks).
+
+### Secret vs variable
+
+Both are environment variables injected at container start. The difference:
+
+| Kind | Storage | Visible in API? | Use for |
+| --- | --- | --- | --- |
+| **Secret** | AES-GCM encrypted with a per-user key | Never returned | API keys, tokens, passwords |
+| **Variable** | Plaintext | Returned in listings | Public URLs, feature flags |
+
+See [Secrets](/agents/secrets).
+
+### Channel
+
+A messaging surface the agent can be reached on - Telegram, Slack, Discord (WhatsApp coming). Configured per-agent. See [Channels](/agents/channels).
+
+### Route
+
+A mapping from an external URL prefix or domain to a container port. Lets you expose web apps and APIs running inside the agent. See [Routes & Domains](/agents/routes).
+
+### Task
+
+A scheduled prompt or system event. Three schedule kinds: `at` (one-shot), `every` (interval), `cron`. See [Tasks](/agents/tasks).
+
+### Lifecycle script
+
+Shell commands run by the agent runner at well-defined points:
+
+| Script | When | Working dir | Log file | Timeout |
+| --- | --- | --- | --- | --- |
+| `build` | After deploy, after each `git push`, on Retry Scripts | `/home/node/clawd` | `/tmp/user-build.log` | 5 min |
+| `start` | After successful `build`, on agent boot | `/home/node/clawd` | `/tmp/user-start.log` | None (detached) |
+
+Defined in `scripts` in [`manifest.json`](/agents/manifest#scripts).
+
+### Snapshot
+
+A capture of the agent's workspace pinned to IPFS as a single CID. Created automatically every minute when changes are detected, plus on demand via `POST /v0/agents/{agentId}/snapshots/sync`. Reset to any historical snapshot via `POST /v0/agents/{agentId}/snapshots/reset`. See [Files & Snapshots](/agents/snapshots).
+
+### Device
+
+A client paired with an agent (CLI, mobile, browser session) - approval-gated for security. Listed at `GET /v0/agents/{agentId}/devices`. See [Danger → Devices](/agents/devtools#device-pairing).
+
+### Template
+
+A pre-configured agent (manifest + workspace files + skill list) packaged for one-click deployment. Published on the [Marketplace](https://agents.pinata.cloud/marketplace) or kept private in [My Templates](https://agents.pinata.cloud/templates). See [Templates](/agents/templates/overview).
+
+### Issue
+
+(Closed beta, `@pinata.cloud` accounts only.) Kanban-style work item assigned to an agent - title + prompt + optional repo. The agent runs, you review the workspace diff, then approve or revert.
+
+## Filesystem reference
+
+Paths agents and developers reach for most often inside the container:
+
+| Path | What's there |
+| --- | --- |
+| `/home/node/clawd/` | Runner root - where `build`/`start` execute |
+| `/home/node/clawd/workspace/` | Agent workspace (see anatomy above) |
+| `/home/node/clawd/workspace/skills/<name>/` | Attached skill files |
+| `/home/node/clawd/workspace/uploads/` | Uploaded files |
+| `/home/node/.openclaw/openclaw.json` | OpenClaw runtime config |
+| `/tmp/openclaw/openclaw-YYYY-MM-DD.log` | Daily OpenClaw log file |
+| `/tmp/user-build.log` | `build` script output |
+| `/tmp/user-start.log` | `start` script output |
+
+## Reserved ports & names
+
+| Reserved | Why |
+| --- | --- |
+| Port `18789` | Gateway listens here |
+| Subdomains containing `pinata` | Reserved for first-party use |
+| Specific reserved domain suffixes | Reserved for the platform |
+
+Path routes must use ports between `1025` and `65535`, excluding `18789`. See [Routes](/agents/routes).
+
+## Identifier formats
+
+Quick reference for the IDs you'll see in URLs and API responses:
+
+| Identifier | Format | Example |
+| --- | --- | --- |
+| Agent ID | Random short slug | `x0i33jye` |
+| Snapshot CID | IPFS CIDv1, `bafy...` or `Qm...` | `QmUMfo19uXMdBSXLiZAz7w...` |
+| Skill CID | IPFS CIDv1, `bafy...` | `bafybeicglyjdb6w...` |
+| Skill slug | `@<owner>/<name>` (lowercase, hyphens) | `@pinata/api` |
+| Custom domain ID | UUID | `2fcd2a0b-aa70-432d-a310-678e01570e65` |
+| Secret ID | Random opaque string | (server-assigned) |
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Manifest reference" icon="file-code" href="/agents/manifest">
+    Every field in `manifest.json`
+  </Card>
+  <Card title="HTTP API" icon="plug" href="/agents/api">
+    Auth, endpoints, and examples
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/agents/troubleshooting">
+    Debug a stuck agent
+  </Card>
+  <Card title="Error reference" icon="circle-exclamation" href="/agents/errors">
+    Look up an API error
+  </Card>
+</CardGroup>

--- a/agents/console.mdx
+++ b/agents/console.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Console"
-description: "Terminal access to your agent's container"
+description: "A real terminal inside your agent's container"
 icon: "terminal"
 ---
 
-Open your agent → **Console** to get a shell directly into your agent's container.
+The Console tab is a shell. You get an interactive prompt inside your agent's container, with the same workspace your agent reads and writes.
 
 <Frame>
   ![Image](/images/image-37.png)
@@ -17,15 +17,67 @@ Working directory: /home/node/clawd/workspace
 ~/clawd/workspace $
 ```
 
-This is a full terminal session. You can:
+Anything you can do with a shell, you can do here:
 
-- Run commands in your agent's environment
-- Inspect files and directories
-- Debug issues in real-time
-- Install packages or run scripts manually
+- Run `bash`, `python`, `node`, `git`, `curl`, `jq`
+- Tail log files: `tail -f /tmp/user-build.log`
+- Check what the agent sees: `env | sort`
+- Confirm a service is listening: `ss -tlnp`
+- Edit a file with `vi` or `nano`
 
-The working directory starts at `/home/node/clawd/workspace` - the same workspace your agent uses.
+The session starts in `/home/node/clawd/workspace` — the same workspace shown on the Files tab. Skills live under `skills/`, uploaded files under `uploads/`.
 
 <Tip>
-  Click the expand icon in the top-right for fullscreen mode.
+  The button in the top-right of the panel switches to fullscreen mode, which is much more pleasant for anything beyond a one-liner.
 </Tip>
+
+## When to reach for the Console
+
+The Console is the second-best debugging tool, after Logs. Use it when:
+
+- Logs show an error and you need to look at a file to understand it
+- A lifecycle script failed and you want to read `/tmp/user-build.log` or `/tmp/user-start.log`
+- You want to confirm a process is actually running (`ps aux | grep <name>`)
+- You want to reproduce a one-off command the agent ran
+
+Quick checks worth knowing:
+
+```bash
+# What did the build script say?
+tail -n 200 /tmp/user-build.log
+
+# What did the start script say?
+tail -n 200 /tmp/user-start.log
+
+# Latest OpenClaw log
+ls -la /tmp/openclaw/
+
+# OpenClaw runtime config
+cat /home/node/.openclaw/openclaw.json
+
+# Manifest the agent is using
+cat workspace/manifest.json
+
+# Is anything listening on common dev ports?
+ss -tlnp
+```
+
+For workflows by symptom, see [Troubleshooting](/agents/troubleshooting).
+
+## Running a command from outside the UI
+
+If you're scripting against an agent, hit the API:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"command":"ls -la workspace","cwd":"/home/node/clawd"}' \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/console/exec
+```
+
+The response is JSON: `{ stdout, stderr, exitCode, command, timestamp }`.
+
+<Warning>
+  Console access is full shell access. Anyone with the gateway token has it. Treat the token like a server credential.
+</Warning>

--- a/agents/devtools.mdx
+++ b/agents/devtools.mdx
@@ -1,59 +1,156 @@
 ---
 title: "Danger"
-description: "Agent details, configuration, restart, and delete"
+description: "Full agent inventory, plus restart and delete"
 icon: "triangle-exclamation"
 ---
 
-Open your agent → **Danger** to see agent details and destructive actions.
+The Danger tab does two things. First, it's the single place where you can see *everything* about an agent — every secret attached, every skill installed, every channel configured, every snapshot CID. It's also where you'll find restart, settings edit, and delete.
 
-This page shows your agent's current state under **General**, with actions at the bottom.
+The name is mostly about the buttons at the bottom — Restart Gateway is disruptive, Delete is permanent. But it's also the page you'll open most often when you're answering "how is this agent actually configured?"
 
-## Agent Details
+## Layout
 
-| Field | Description |
+Two big sections.
+
+- **General** — agent details, workspace state, lifecycle scripts, channels, skills, devices, secrets. One row at a time.
+- **Actions** — three buttons: Restart Gateway, OpenClaw Settings UI, Delete This Agent.
+
+## Agent details
+
+The first block in **General** is the agent itself:
+
+| Field | What it is |
 | --- | --- |
-| **Agent ID** | Unique identifier for API calls and URLs |
-| **Status** | Running, starting, or stopped |
-| **Name** | Display name |
-| **Version** | OpenClaw version (click **Change** to update) |
-| **Config** | Path to `openclaw.json` (click **Edit** to modify) |
-| **Gateway Token** | Auth token for protected routes |
+| **Agent ID** | The unique slug used in URLs and API calls (e.g. `x0i33jye`) |
+| **Status** | `starting`, `running`, or `not_running` |
+| **Name** | What you named it |
+| **Engine** | The container engine — `openclaw` (default) or `hermes` |
+| **Version** | Engine version. **Change** lets you bump it. |
+| **Config** | Path to `openclaw.json` inside the container. **Edit** opens an editor. |
+| **Gateway Token** | The credential used to authenticate against the agent's own subdomain. See [API → Gateway token](/agents/api#gateway-token). |
 | **Created** | When the agent was created |
 | **Base URL** | `https://{agentId}.agents.pinata.cloud` |
 
-Click **manifest.json schema** to see all configuration options.
+The **manifest.json schema** link at the top of this section jumps to the [full field reference](/agents/manifest).
 
-Below the agent details you'll see a full overview of everything attached to your agent - workspace state, lifecycle scripts, scheduled tasks, channels, custom domains, skills (with their CIDs), paired devices, and secrets (with sync status showing when each was last synced).
+## Workspace
 
-## Editing Configuration
+| Field | What it shows |
+| --- | --- |
+| **Path** | The workspace directory inside the container (default `/home/node/clawd/workspace`) |
+| **Snapshot CID** | IPFS CID of the most recent synced snapshot |
+| **Last Sync** | How recently the workspace was captured |
 
-Click **Edit** next to the Config row to modify your agent's `openclaw.json`. This is where you can tweak advanced OpenClaw settings. Changes are validated before being saved.
+For diffs and restore, use the [Files](/agents/snapshots) tab.
 
-## Updating OpenClaw
+## Lifecycle Scripts
 
-Click **Change** next to the Version field to check for and apply OpenClaw updates.
+Whether your `build` and `start` scripts are configured, and their current status. The states are self-explanatory: `Not configured`, `pending`, `running`, `success`, `failed`.
 
-## Restart Gateway
+If something failed, use the **OpenClaw Settings UI** action or `POST /v0/agents/{agentId}/scripts/retry` to re-run the lifecycle. Logs end up in `/tmp/user-build.log` and `/tmp/user-start.log` — see [Manifest → Scripts](/agents/manifest#scripts) for the details.
 
-Restarts your agent's gateway process. Use this when:
+## Scheduled Tasks
 
-- Your agent is behaving unexpectedly
-- You need to apply configuration changes
-- Connections seem stuck
+Just a status summary. Manage them on the [Tasks](/agents/tasks) tab.
+
+## Channels
+
+A quick rollup — for each of Telegram, Slack, Discord, and WhatsApp, you'll see either `Enabled` or `Not configured`.
+
+## Skills
+
+Every attached skill, its installed version, and its IPFS CID. The same info as the [Skills](/agents/skills) tab, in a flat-list format.
+
+## Devices
+
+Clients paired with the agent — mobile, the CLI, browser sessions. Each is listed with its status (`paired`, `pending`) and last activity.
+
+<a id="device-pairing"></a>
+### Device pairing
+
+Some clients (the CLI in particular) need to be approved before they can talk to the agent. The flow:
+
+1. The client asks to pair. A pending entry appears in this list.
+2. You approve it — either click **Approve** here or hit `POST /v0/agents/{agentId}/devices/{requestId}/approve`.
+3. To approve everything pending at once: `POST /v0/agents/{agentId}/devices/approve-all`.
+
+## Secrets
+
+Every attached secret, with a **Synced** indicator that tells you whether the *running* gateway has picked up the latest value. If you updated a secret and the indicator says out of sync, restart the gateway.
+
+## Actions
+
+### Restart Gateway
+
+Restarts the gateway process inside the container. Use it when:
+
+- You changed a secret, skill, or channel and want the agent to actually pick it up
+- The agent is misbehaving
+- WebSocket connections look stuck
 
 <Warning>
-  Restarting temporarily disconnects all clients. May take a few minutes.
+  Restarting disconnects all clients (chat, channel bots, custom domain traffic) for a minute or two.
 </Warning>
 
-## Delete Agent
+From the API:
 
-Permanently deletes your agent, including:
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/restart
+```
+
+### OpenClaw Settings UI
+
+Opens OpenClaw's internal settings panel. This is a low-level config editor for the engine itself — useful for advanced debugging.
+
+<Warning>
+  Misconfiguration here can break the agent. For day-to-day config, edit `manifest.json` instead. See the [manifest reference](/agents/manifest).
+</Warning>
+
+### Edit config
+
+The **Edit** button next to the **Config** row opens `openclaw.json` directly. Changes are validated server-side before they're written.
+
+You can also validate any config string without applying it:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"config":"{...}"}' \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/config/validate
+```
+
+This validates `openclaw.json` (the runtime config), not `manifest.json`. For manifest validation, see [Manifest → Validation](/agents/manifest#validation).
+
+### Update OpenClaw
+
+The **Change** button next to the Version field checks for updates and applies them. Equivalent CLI calls:
+
+```bash
+# Check
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/update
+
+# Apply
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"tag":"latest"}' \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/update
+```
+
+### Delete Agent
+
+Permanent. Removes:
 
 - The container
 - All workspace files and snapshots
-- All R2 data
+- All R2 storage tied to the agent
 - Channel configurations
+- Custom domains
 
 <Warning>
-  Deletion cannot be undone.
+  There's no undo. The agent ID is gone — it won't be reissued.
 </Warning>

--- a/agents/errors.mdx
+++ b/agents/errors.mdx
@@ -1,0 +1,188 @@
+---
+title: "Error Reference"
+sidebarTitle: "Errors"
+description: "Look up an API error code and how to resolve it"
+icon: "circle-exclamation"
+---
+
+Every API error comes back as JSON with a single `error` field and an HTTP status code:
+
+```json
+{ "error": "Validation failed: skills exceeds maximum of 10" }
+```
+
+This page maps the codes you'll actually see in the wild to a cause and a fix. For step-by-step debugging, see [Troubleshooting](/agents/troubleshooting).
+
+## By HTTP status
+
+### `400 Bad Request`
+
+The request shape or content is invalid.
+
+| When you'll see it | Likely cause | Fix |
+| --- | --- | --- |
+| `POST /v0/agents` | `name` missing, too long, or contains banned characters | Trim or rename. Max 100 chars. |
+| `POST /v0/secrets` | `name` or `value` empty | Provide both |
+| `POST /v0/agents/.../skills` | More than 10 skills attached | Detach skills first |
+| `POST /v0/agents/.../console/exec` | Empty `command` | Provide the command string |
+| `POST /v0/agents/.../snapshots/sync` | Storage not configured for this workspace | Pinata storage isn't provisioned - contact support |
+| `POST /v0/agents/.../config/validate` | `config` field isn't valid JSON | Fix syntax |
+| `POST /v0/agents/.../domains` | Both `subdomain` and `customDomain` provided, banned name, or limit reached | Pick one. Avoid names containing "pinata". Max 5 domains. |
+| `POST /v0/agents/.../snapshots/reset` | `snapshotCid` missing or malformed | Use a CID from the snapshot list |
+| `POST /v0/agents/.../channels/{channel}` | Token missing on initial setup, or unsupported channel name | Provide `botToken` (and `appToken` for Slack) |
+| `POST /v0/agents/.../files/upload` | `filename` empty or `contentBase64` malformed | Sanitize filename, base64-encode without the data URL prefix |
+
+### `401 Unauthorized`
+
+No credential, or the credential was rejected before reaching authorization.
+
+| Cause | Fix |
+| --- | --- |
+| Missing `Authorization` header | Add `Authorization: Bearer <token>` |
+| Pinata JWT expired or revoked | Generate a new key in [Account → API Keys](/account-management/api-keys) |
+| Gateway token rotated | Copy the current value from Danger → Agent → Gateway Token |
+| Token from a different workspace | Switch workspaces in **Account → Workspaces** or use a key from the right workspace |
+
+### `403 Forbidden`
+
+Authenticated, but the action isn't allowed.
+
+| Cause | Fix |
+| --- | --- |
+| Agent limit reached on `POST /v0/agents` | Upgrade your plan or delete an unused agent |
+| Free plan trying to use a paid feature (channels, custom domains) | Upgrade plan |
+| Workspace permission denied | Ask the workspace admin for access |
+| `404` returned where you expected `403` (Issues API on non-internal accounts) | Issues is closed beta to `@pinata.cloud` only |
+
+### `404 Not Found`
+
+The resource doesn't exist (or you're not allowed to know it exists).
+
+| Cause | Fix |
+| --- | --- |
+| Wrong `agentId` | Check the ID from the Danger page or `GET /v0/agents` |
+| `snapshotCid` not in this agent's history | Use one from `GET /v0/agents/{agentId}/snapshots` |
+| Skill CID/slug not installed in your library | Install via Skills Library or `POST /v0/clawhub/{slug}/install` |
+| Template slug/ID doesn't exist or was archived | List `GET /v0/templates` |
+| Custom domain ID not on this agent | List `GET /v0/agents/{agentId}/domains` |
+| Issues endpoint hit by a non-internal account | Closed beta - returns `404` by design |
+
+### `409 Conflict`
+
+Resource state is incompatible with the request.
+
+| Cause | Fix |
+| --- | --- |
+| Duplicate secret name on `POST /v0/secrets` | Use a different name or update the existing one |
+| Two credentials for the same provider attached (e.g. `ANTHROPIC_API_KEY` + Claude subscription) | Detach one |
+| Custom domain already registered (verified) | Pick a different name or delete the existing registration |
+| Subdomain collides with another tenant | Generate a new one or pick a different name |
+| Trying to delete a secret still attached to an agent | Detach from agents first |
+| Skill version conflict during update | Resolve via `POST /v0/agents/{agentId}/skills/{skillId}/update` |
+
+### `413 Payload Too Large`
+
+File upload exceeded the per-request limit.
+
+| Cause | Fix |
+| --- | --- |
+| `POST /v0/agents/{agentId}/files/upload` body too big | Chunk the upload, or push the file via git, or stream it from inside the container |
+
+### `500 Internal Server Error`
+
+Something blew up on the server. The `error` field usually has the underlying message.
+
+Common variants:
+
+| Message hint | Cause | Fix |
+| --- | --- | --- |
+| `Gateway failed to start` after agent create | Provisioning succeeded but the gateway crashed | Wait 30s and retry, or check Logs |
+| `Sync failed` | Workspace snapshot upload to Pinata IPFS failed | Retry; if persistent, check Pinata status |
+| `CLI error` on `GET /v0/agents/{agentId}/devices` | Underlying OpenClaw CLI returned non-zero | Check Logs for OpenClaw errors; restart gateway |
+| `Reset failed` | Git reset to the snapshot commit failed | The commit hash may be missing - try a different snapshot |
+| `Configuration failed` on channel configure | OpenClaw rejected the channel config | Validate token format (e.g. Slack `xoxb-` / `xapp-`) |
+| `Execution failed` on console exec | Command shell terminated unexpectedly | Inspect the command; if hung, restart gateway |
+
+### `503 Service Unavailable`
+
+A dependency the server needs is down.
+
+| Cause | Fix |
+| --- | --- |
+| `POST /v0/secrets` returns 503 with "Secrets not configured" | Server-side encryption key not provisioned. Contact support. |
+| Snapshot/IPFS backend unreachable | Retry; check Pinata status page |
+
+## By symptom
+
+### "I just created the agent and the chat shows offline"
+
+The container takes ~30 seconds to provision. A `500` with the agent body in the response means provisioning succeeded but the gateway didn't start cleanly - the agent will appear in your list and you can restart it.
+
+### "My push to the workspace returns auth errors"
+
+Re-grab the URL with **Copy with Token** on the Files tab. The gateway token may have been rotated.
+
+### "Tasks return 500 from `GET /v0/agents/.../tasks`"
+
+This usually means the OpenClaw CLI inside the container failed. Restart the gateway; if it keeps failing, check the Logs filtered to `cron/runner`.
+
+### "Channel configure returns 500"
+
+OpenClaw could not write the channel config or restart. Almost always a malformed token or a channel that's already enabled. Re-check the token, then **Reconfigure**.
+
+### "Domain stuck `pending_ownership`"
+
+Your `_pinata-verify.<domain>` TXT record isn't visible. Confirm with `dig TXT _pinata-verify.<domain> +short` and wait for propagation.
+
+### "Issues endpoints all return 404"
+
+Issues is closed beta and restricted to `@pinata.cloud` accounts today.
+
+## Error string lookup
+
+Verbatim messages you'll see in the `error` field of a response or the `errors[]` array from validators. Search this page for the literal string to jump to its meaning.
+
+| Error string | Where it appears | Meaning |
+| --- | --- | --- |
+| `Validation failed` | Most `400` responses | One or more fields failed schema validation - check the rest of the message |
+| `Missing userId` | Several JWT-protected endpoints | Pinata JWT couldn't be resolved to a user - regenerate the key |
+| `Agent limit reached` | `POST /v0/agents` (`403`) | Workspace at its agent quota - upgrade or delete an unused agent |
+| `Storage not configured` | `POST /v0/agents/{agentId}/snapshots/sync` (`400`) | Workspace has no backing storage; contact support |
+| `Sync failed` | Snapshot sync (`500`) | IPFS pin or workspace serialization failed - retry |
+| `Snapshot not found` | `POST /v0/agents/{agentId}/snapshots/reset` (`404`) | Snapshot CID isn't in this agent's history |
+| `Invalid snapshot CID` | Snapshot reset (`400`) | The provided CID didn't parse |
+| `Unsupported channel` | `DELETE /v0/agents/{agentId}/channels/{channel}` (`400`) | Channel must be `telegram` / `slack` / `discord` / `whatsapp` |
+| `Configuration failed` | Channel configure (`500`) | OpenClaw rejected the token/config |
+| `Removal failed` | Channel delete (`500`) | OpenClaw failed to remove and restart |
+| `Invalid command` | Console exec (`400`) | `command` field empty or invalid `cwd` |
+| `Execution failed` | Console exec (`500`) | Shell exited unexpectedly |
+| `Invalid JSON` | Config validate / write (`400`) | The `config` field isn't valid JSON |
+| `Validation command failed` | `POST /v0/agents/{agentId}/config/validate` (`500`) | OpenClaw CLI returned non-zero |
+| `Failed to read config` | `GET /v0/agents/{agentId}/config` (`500`) | Couldn't read `openclaw.json` |
+| `Failed to write config` | `PUT /v0/agents/{agentId}/config` (`500`) | Couldn't write `openclaw.json` |
+| `Invalid version` | `POST /v0/agents/{agentId}/restart` (`400`) | Requested OpenClaw version doesn't exist |
+| `Restart failed` | Restart (`500`) | Gateway didn't come back up - check Logs |
+| `Script launch failed` | `POST /v0/agents/{agentId}/scripts/retry` (`500`) | Build or start couldn't be launched |
+| `File too large` | `POST /v0/agents/{agentId}/files/upload` (`413`) | Body over the upload limit - chunk or push via git |
+| `CLI error` | Several OpenClaw-backed endpoints (`500`) | Underlying `openclaw` CLI returned non-zero - check Logs |
+| `Token generation failed` | `POST /v0/agents/{agentId}/platform/token` (`500`) | Platform JWT couldn't be minted - rotate gateway token |
+| `Secrets not configured` | `POST /v0/secrets` (`503`) | Server-side encryption key not provisioned - contact support |
+| `Duplicate secret name` | `POST /v0/secrets` (`409`) | Secret name is already taken |
+| `Conflicting secrets` | `POST /v0/agents/{agentId}/secrets` (`409`) | Attaching two creds for the same provider (e.g. API key + subscription) |
+| `Invalid parameters` | Tasks create (`400`) | One of `name`, `schedule`, or `payload` is missing or malformed |
+| `Failed to create cron job` | Tasks create (`500`) | OpenClaw rejected the cron config |
+| `Failed to list cron jobs` | Tasks list (`500`) | OpenClaw CLI failed |
+| `version must be 1` | Manifest validate / template validate | `manifest.json` missing or wrong `version` |
+| `agent.name is required` | Manifest validate | `agent.name` missing or empty |
+| `skills exceeds maximum of 10` | Manifest validate | Too many skills listed |
+| `routes exceeds maximum of 10` | Manifest validate | Too many routes listed |
+| `tasks exceeds maximum of 20` | Manifest validate | Too many tasks listed |
+| `routes[i].port reserved` | Manifest validate | Used `18789` (reserved for the gateway) |
+| `routes[i].port out of range` | Manifest validate | Port must be `1025`-`65535` |
+
+## See also
+
+- [Concepts](/agents/concepts) - terminology and how the pieces fit
+- [Troubleshooting](/agents/troubleshooting) - step-by-step debugging by symptom
+- [HTTP API](/agents/api) - auth and base URLs
+- [Manifest reference](/agents/manifest) - manifest schema details

--- a/agents/errors.mdx
+++ b/agents/errors.mdx
@@ -138,17 +138,16 @@ Your `_pinata-verify.<domain>` TXT record isn't visible. Confirm with `dig TXT _
 
 Issues is closed beta and restricted to `@pinata.cloud` accounts today.
 
-## Error string lookup
+## Common error responses
 
-Verbatim messages you'll see in the `error` field of a response or the `errors[]` array from validators. Search this page for the literal string to jump to its meaning.
+Errors documented in the API spec, grouped by where they appear. Use this as a starting point when you're trying to interpret an error response — the exact string returned by the API is the source of truth.
 
-| Error string | Where it appears | Meaning |
+| Response | Where it appears | What it means |
 | --- | --- | --- |
-| `Validation failed` | Most `400` responses | One or more fields failed schema validation - check the rest of the message |
-| `Missing userId` | Several JWT-protected endpoints | Pinata JWT couldn't be resolved to a user - regenerate the key |
-| `Agent limit reached` | `POST /v0/agents` (`403`) | Workspace at its agent quota - upgrade or delete an unused agent |
+| `Missing userId` | Several JWT-protected endpoints | Pinata JWT couldn't be resolved to a user — regenerate the key |
+| `Agent limit reached` | `POST /v0/agents` (`403`) | Workspace at its agent quota — upgrade or delete an unused agent |
 | `Storage not configured` | `POST /v0/agents/{agentId}/snapshots/sync` (`400`) | Workspace has no backing storage; contact support |
-| `Sync failed` | Snapshot sync (`500`) | IPFS pin or workspace serialization failed - retry |
+| `Sync failed` | Snapshot sync (`500`) | IPFS pin or workspace serialization failed — retry |
 | `Snapshot not found` | `POST /v0/agents/{agentId}/snapshots/reset` (`404`) | Snapshot CID isn't in this agent's history |
 | `Invalid snapshot CID` | Snapshot reset (`400`) | The provided CID didn't parse |
 | `Unsupported channel` | `DELETE /v0/agents/{agentId}/channels/{channel}` (`400`) | Channel must be `telegram` / `slack` / `discord` / `whatsapp` |
@@ -161,24 +160,17 @@ Verbatim messages you'll see in the `error` field of a response or the `errors[]
 | `Failed to read config` | `GET /v0/agents/{agentId}/config` (`500`) | Couldn't read `openclaw.json` |
 | `Failed to write config` | `PUT /v0/agents/{agentId}/config` (`500`) | Couldn't write `openclaw.json` |
 | `Invalid version` | `POST /v0/agents/{agentId}/restart` (`400`) | Requested OpenClaw version doesn't exist |
-| `Restart failed` | Restart (`500`) | Gateway didn't come back up - check Logs |
+| `Restart failed` | Restart (`500`) | Gateway didn't come back up — check Logs |
 | `Script launch failed` | `POST /v0/agents/{agentId}/scripts/retry` (`500`) | Build or start couldn't be launched |
-| `File too large` | `POST /v0/agents/{agentId}/files/upload` (`413`) | Body over the upload limit - chunk or push via git |
-| `CLI error` | Several OpenClaw-backed endpoints (`500`) | Underlying `openclaw` CLI returned non-zero - check Logs |
-| `Token generation failed` | `POST /v0/agents/{agentId}/platform/token` (`500`) | Platform JWT couldn't be minted - rotate gateway token |
-| `Secrets not configured` | `POST /v0/secrets` (`503`) | Server-side encryption key not provisioned - contact support |
+| `File too large` | `POST /v0/agents/{agentId}/files/upload` (`413`) | Body over the upload limit — chunk or push via git |
+| `CLI error` | Several OpenClaw-backed endpoints (`500`) | Underlying `openclaw` CLI returned non-zero — check Logs |
+| `Token generation failed` | `POST /v0/agents/{agentId}/platform/token` (`500`) | Platform JWT couldn't be minted — rotate gateway token |
+| `Secrets not configured` | `POST /v0/secrets` (`503`) | Server-side encryption key not provisioned — contact support |
 | `Duplicate secret name` | `POST /v0/secrets` (`409`) | Secret name is already taken |
 | `Conflicting secrets` | `POST /v0/agents/{agentId}/secrets` (`409`) | Attaching two creds for the same provider (e.g. API key + subscription) |
 | `Invalid parameters` | Tasks create (`400`) | One of `name`, `schedule`, or `payload` is missing or malformed |
 | `Failed to create cron job` | Tasks create (`500`) | OpenClaw rejected the cron config |
 | `Failed to list cron jobs` | Tasks list (`500`) | OpenClaw CLI failed |
-| `version must be 1` | Manifest validate / template validate | `manifest.json` missing or wrong `version` |
-| `agent.name is required` | Manifest validate | `agent.name` missing or empty |
-| `skills exceeds maximum of 10` | Manifest validate | Too many skills listed |
-| `routes exceeds maximum of 10` | Manifest validate | Too many routes listed |
-| `tasks exceeds maximum of 20` | Manifest validate | Too many tasks listed |
-| `routes[i].port reserved` | Manifest validate | Used `18789` (reserved for the gateway) |
-| `routes[i].port out of range` | Manifest validate | Port must be `1025`-`65535` |
 
 ## See also
 

--- a/agents/logs.mdx
+++ b/agents/logs.mdx
@@ -66,4 +66,4 @@ Returns the latest 100 lines as a single string. For full streaming, the UI uses
 | `skill/<name>` | Output from a specific skill |
 | `script/build`, `script/start` | Lifecycle script output (also tee'd to `/tmp/user-build.log` and `/tmp/user-start.log`) |
 
-If something's broken, start at ERROR. If you see ERROR lines and can't make sense of them, [Troubleshooting](/agents/troubleshooting) maps symptoms to fixes, and the [Error reference](/agents/errors) maps verbatim error strings to causes.
+If something's broken, start at ERROR. If you see ERROR lines and can't make sense of them, [Troubleshooting](/agents/troubleshooting) maps symptoms to fixes, and the [Error reference](/agents/errors) covers common API error responses.

--- a/agents/logs.mdx
+++ b/agents/logs.mdx
@@ -1,43 +1,69 @@
 ---
 title: "Logs"
-description: "Real-time logs with filtering and export"
+description: "Stream OpenClaw's output in real time"
 icon: "scroll"
 ---
 
-Open your agent → **Logs** to see real-time output from OpenClaw.
+The Logs tab is a live stream of what OpenClaw is doing inside your agent. New entries appear without refreshing — the tab uses a WebSocket under the hood. If the small status badge in the header reads `WEBSOCKET CONNECTED`, you're streaming. If it reads `WEBSOCKET NOT CONNECTED`, either the agent isn't running or the connection dropped — hit the refresh button or check the agent's status.
 
 <Frame>
   ![Image](/images/image-38.png)
 </Frame>
 
+## Reading the stream
+
+Each log line has four parts:
+
+- **Timestamp** — when it happened
+- **Level** — severity (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`)
+- **Source** — which component generated the line (e.g. `gateway/reload`, `cron/runner`)
+- **Message** — the content
+
+Click the **+** on the left of any row to expand it. Useful for stack traces and structured fields that don't fit on a single line.
+
 ## Filtering
 
-Use the checkboxes to filter by log level:
+The six colored checkboxes — TRACE, DEBUG, INFO, WARN, ERROR, FATAL — toggle log levels on and off. When you're hunting a problem, uncheck everything except WARN and above to cut the noise.
 
-- **TRACE** - Most verbose, detailed execution flow
-- **DEBUG** - Debugging information
-- **INFO** - General operational messages
-- **WARN** - Warning conditions
-- **ERROR** - Error conditions
-- **FATAL** - Critical failures
+The **Search logs** box does a substring match against the message. Combine with level filters: "show me ERROR lines mentioning `telegram`."
 
-The search box filters log content. Enable **AUTO-FOLLOW** to automatically scroll to new entries as they appear.
-
-## Log Entries
-
-Each entry shows:
-
-- **Timestamp** - When the event occurred
-- **Level** - Severity (INFO, ERROR, etc.)
-- **Source** - Which component generated the log (e.g., `gateway/reload`)
-- **Message** - The log content
-
-Click the **+** button to expand an entry and see the full message.
+The **AUTO-FOLLOW** checkbox keeps the view pinned to the latest entry. Uncheck it when you want to scroll back without the view jumping.
 
 ## Exporting
 
-Click **EXPORT VISIBLE** to download the currently filtered logs. This exports only what matches your current filters - useful for sharing specific issues or keeping records.
+**EXPORT VISIBLE** downloads whatever the current filters are showing — useful for sharing with support or filing an issue. It's only what you see; the export respects your filters.
 
-## Log File
+## Where the logs live on disk
 
-Logs are written to `/TMP/OPENCLAW/OPENCLAW-{date}.LOG`. A new file is created each day.
+Inside the container, OpenClaw writes daily log files to `/tmp/openclaw/openclaw-{date}.log`. From the [Console](/agents/console):
+
+```bash
+ls /tmp/openclaw/
+tail -f /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log
+```
+
+That's identical to what the Logs tab streams, with one difference: only the last 100 lines are retained when the gateway restarts. If you need long-term retention, export periodically.
+
+## Reading logs over the API
+
+For scripts and incident response:
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/logs
+```
+
+Returns the latest 100 lines as a single string. For full streaming, the UI uses a WebSocket on the agent's subdomain — see [API → Streaming logs](/agents/api#streaming-logs).
+
+## Common sources, and what they tell you
+
+| Source | What it means |
+| --- | --- |
+| `gateway/reload` | Gateway reloaded its configuration — usually after a secret, skill, or channel change |
+| `gateway/ws` | WebSocket lifecycle (connect, disconnect, reconnect) |
+| `cron/runner` | A scheduled task fired — which one, and what happened |
+| `agent/turn` | One conversation turn — request in, response out |
+| `skill/<name>` | Output from a specific skill |
+| `script/build`, `script/start` | Lifecycle script output (also tee'd to `/tmp/user-build.log` and `/tmp/user-start.log`) |
+
+If something's broken, start at ERROR. If you see ERROR lines and can't make sense of them, [Troubleshooting](/agents/troubleshooting) maps symptoms to fixes, and the [Error reference](/agents/errors) maps verbatim error strings to causes.

--- a/agents/manifest.mdx
+++ b/agents/manifest.mdx
@@ -1,0 +1,272 @@
+---
+title: "Manifest Reference"
+sidebarTitle: "Manifest"
+description: "Every field in manifest.json, the source of truth for an agent's configuration"
+icon: "file-code"
+---
+
+`manifest.json` lives at the root of every agent's workspace. It controls identity, lifecycle scripts, secrets, skills, routes, channels, scheduled tasks, and (for templates) marketplace metadata. This page documents every field at the version 1 schema.
+
+The schema is published at:
+
+```
+https://agents.pinata.cloud/schemas/manifest.v1.json
+```
+
+Add a `$schema` line so editors can autocomplete and validate:
+
+```json
+{
+  "$schema": "https://agents.pinata.cloud/schemas/manifest.v1.json",
+  "version": 1,
+  "engine": "openclaw",
+  "agent": { "name": "My Agent" }
+}
+```
+
+## Top-level fields
+
+| Field | Type | Required | Description |
+| --- | --- | :---: | --- |
+| `$schema` | string | optional | Schema URL for editor support |
+| `version` | integer | yes | Manifest version - currently `1` |
+| `engine` | string | optional | Container engine - `openclaw` (default) or `hermes` |
+| `agent` | object | yes | Agent identity (see below) |
+| `model` | string | optional | Default model in `<provider>/<model>` form |
+| `secrets` | array | optional | Encrypted credentials this agent requires |
+| `skills` | array | optional | Up to 10 skill slugs or CIDs |
+| `tasks` | array | optional | Up to 20 scheduled tasks |
+| `scripts` | object | optional | Lifecycle hooks (`build`, `start`) |
+| `routes` | array | optional | Up to 10 port-forwarding rules |
+| `channels` | object | optional | Messaging channel configuration |
+| `template` | object | optional | Marketplace listing metadata (only for templates) |
+
+## `agent`
+
+Defines the agent's identity. All fields are written into the workspace (mostly `IDENTITY.md`) at deploy time.
+
+```json
+"agent": {
+  "name": "Social Bot",
+  "description": "You manage Socials",
+  "vibe": "Resourceful and opinionated",
+  "emoji": "🤖"
+}
+```
+
+| Field | Type | Limit | Notes |
+| --- | --- | --- | --- |
+| `name` | string | 1-100 chars, **required** | Display name |
+| `description` | string | ≤ 10000 chars | Personality / role |
+| `vibe` | string | ≤ 200 chars | One-line tagline |
+| `emoji` | string | ≤ 32 chars | Visible in lists and avatars |
+
+## `model`
+
+A single default model identifier in `<provider>/<model>` form:
+
+```json
+"model": "anthropic/claude-sonnet-4-6"
+```
+
+Provider must match a connected provider in the [Secrets Vault](/agents/secrets). If a task or session specifies a model that isn't enabled on the agent, the request falls back to this default.
+
+## `secrets`
+
+Declares the secrets this agent needs. These are env-var names - the actual values come from the [Secrets Vault](/agents/secrets) at attach time.
+
+```json
+"secrets": [
+  { "name": "OPENROUTER_API_KEY" },
+  { "name": "TELEGRAM_BOT_TOKEN", "description": "BotFather token", "required": false }
+]
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `name` | string | Environment variable name (e.g. `ANTHROPIC_API_KEY`) |
+| `description` | string | Shown on the deploy form |
+| `required` | boolean | Default `true`. `false` makes the field optional in the deploy wizard |
+
+## `skills`
+
+Up to 10 skill references - either ClawHub slugs (resolves to the latest version) or IPFS CIDs (byte-stable).
+
+```json
+"skills": [
+  "@pinata/api",
+  "@pinata/memory-salience",
+  "bafybeicglyjdb6wrrcbfyu6i2fe4lpxdxgvfvlht7yzdim7cvwt656whue"
+]
+```
+
+Each attached skill is unpacked under `workspace/skills/<skill-name>/`. See [Skills](/agents/skills).
+
+## `tasks`
+
+Scheduled prompts. Up to 20 per agent. Full reference in [Tasks](/agents/tasks).
+
+```json
+"tasks": [
+  {
+    "name": "daily-check-in",
+    "schedule": { "kind": "cron", "expr": "0 9 * * *", "tz": "America/Los_Angeles" },
+    "payload": { "kind": "agentTurn", "text": "Summarize yesterday." },
+    "delivery": { "mode": "announce", "channel": "telegram", "to": "123" }
+  }
+]
+```
+
+Schedule kinds: `at` (one-shot ISO timestamp), `every` (`everyMs` interval, optional `staggerMs`), `cron` (`expr` with optional `tz`).
+
+Payload kinds: `agentTurn` (chat message; supports `model`, `thinking`, `timeoutSeconds`) or `systemEvent` (system trigger; provide `message`).
+
+Delivery modes: `none` (default), `announce` (to a channel - set `channel` and `to`), or `webhook` (set `to` to a URL). `bestEffort: true` swallows delivery failures.
+
+`sessionTarget` is `main` or `isolated`. `wakeMode` is `now` or `next-heartbeat`.
+
+## `scripts`
+
+Lifecycle hooks. Both fields are shell commands run by the agent's runner.
+
+```json
+"scripts": {
+  "build": "cd workspace/projects/app && npm install --include=dev",
+  "start": "cd workspace/projects/app && npx vite --host 0.0.0.0"
+}
+```
+
+| Hook | When it runs | Working directory | Output log | Timeout |
+| --- | --- | --- | --- | --- |
+| `build` | After deploy, after each `git push`, on **Retry Scripts** | `/home/node/clawd` | `/tmp/user-build.log` | 5 min |
+| `start` | After a successful `build`, on agent boot | `/home/node/clawd` | `/tmp/user-start.log` | None - runs detached |
+
+If `build` fails, `start` does not run. If `start` crashes, the agent is still healthy - only the user-defined process exits.
+
+**Retry the lifecycle:** `POST /v0/agents/{agentId}/scripts/retry` (or the action on the Danger tab).
+
+**Bind servers to `0.0.0.0`**, not `localhost`, so the gateway can reach them. See [Routes](/agents/routes).
+
+## `routes`
+
+Port-forwarding rules. Up to 10. Each entry maps an external path prefix to a container port.
+
+```json
+"routes": [
+  { "port": 5173, "path": "/app", "protected": false },
+  { "port": 3000, "path": "/api", "protected": true }
+]
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `port` | integer | Container port. 1025-65535. `18789` is reserved. |
+| `path` | string | URL path prefix. Stripped from the request before reaching your service. |
+| `protected` | boolean | `true` requires a gateway token. Defaults to `false`. |
+
+For custom domains, register them through the UI or the [Domains API](/agents/api#custom-domains) - they aren't declared in `manifest.json`.
+
+## `channels`
+
+Configures the messaging channels for this agent. Tokens are usually injected from secrets to avoid leaking into the manifest.
+
+```json
+"channels": {
+  "telegram": {
+    "botToken": "env:TELEGRAM_BOT_TOKEN",
+    "dmPolicy": "pairing",
+    "allowFrom": ["123456789"]
+  },
+  "slack": {
+    "botToken": "env:SLACK_BOT_TOKEN",
+    "appToken": "env:SLACK_APP_TOKEN"
+  },
+  "discord": {
+    "botToken": "env:DISCORD_BOT_TOKEN"
+  }
+}
+```
+
+| Channel | Required fields | Notes |
+| --- | --- | --- |
+| `telegram` | `botToken` | `dmPolicy` (`open` / `pairing`), `allowFrom` (user IDs) |
+| `slack` | `botToken`, `appToken` | Socket Mode + scopes per [Channels](/agents/channels#slack) |
+| `discord` | `botToken` | |
+| `whatsapp` | `dmPolicy`, `allowFrom` | Linking happens on the agent. Coming soon. |
+
+Use `env:VAR_NAME` to read from an environment variable instead of embedding a literal token.
+
+## `template`
+
+Only used when the manifest is the source for a marketplace template. Ignored for direct deploys.
+
+```json
+"template": {
+  "slug": "useful-assistant",
+  "category": "general",
+  "partnerName": "Pinata",
+  "tags": ["assistant", "personal", "productivity"]
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `slug` | Marketplace URL slug. Lowercase, hyphens. |
+| `category` | One of the marketplace categories (e.g. `general`, `defi`, `social`) |
+| `partnerName` | Display name shown on the template card |
+| `tags` | Array of free-text tags for filtering |
+| `paid` | Optional. Set `{ "amount": "1.00", "currency": "USDC" }` for x402 paid templates |
+
+## Validation
+
+<Note>
+  `manifest.json` is different from `openclaw.json` - see [Concepts → manifest vs openclaw config](/agents/concepts#manifest-json-vs-openclaw-json). The `/v0/agents/{agentId}/config/validate` endpoint validates `openclaw.json`, not `manifest.json`.
+</Note>
+
+To validate `manifest.json` ahead of committing, run it through the template validator (which checks `manifest.json` + `README.md` + `workspace/`):
+
+```bash
+# CLI
+pinata agents templates validate https://github.com/user/my-template
+```
+
+```bash
+# Or hit the API directly with the repo URL + ref
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"gitUrl":"https://github.com/user/my-template","ref":"refs/heads/main"}' \
+  https://agents.pinata.cloud/v0/templates/validate
+```
+
+The response is `{ valid: boolean, errors: string[], manifest, readme, files }`.
+
+Common manifest errors you'll see in `errors[]`:
+
+| Error string (verbatim) | Cause |
+| --- | --- |
+| `version must be 1` | Missing or wrong `version` field |
+| `agent.name is required` | The `agent` object is missing or `name` is empty |
+| `agent.name exceeds 100 characters` | Trim the name |
+| `skills exceeds maximum of 10` | More than 10 entries in `skills` |
+| `routes exceeds maximum of 10` | More than 10 entries in `routes` |
+| `tasks exceeds maximum of 20` | More than 20 entries in `tasks` |
+| `routes[i].port reserved` | Used port `18789` |
+| `routes[i].port out of range` | Port outside `1025`-`65535` |
+| `tasks[i].schedule.kind invalid` | Schedule kind isn't `at` / `every` / `cron` |
+| `channels.<channel>.botToken required` | Missing token for initial channel setup |
+
+See [Errors](/agents/errors) for the full HTTP status code reference.
+
+## Minimal Example
+
+The smallest valid manifest:
+
+```json
+{
+  "version": 1,
+  "agent": { "name": "Hello" }
+}
+```
+
+This boots the default `openclaw` engine with no skills, no scripts, and no routes - just a workspace and a chat interface.

--- a/agents/manifest.mdx
+++ b/agents/manifest.mdx
@@ -245,22 +245,21 @@ curl -X POST \
   https://agents.pinata.cloud/v0/templates/validate
 ```
 
-The response is `{ valid: boolean, errors: string[], manifest, readme, files }`.
+The response is `{ valid: boolean, errors: string[], manifest, readme, files }` — any problems with the manifest show up in the `errors` array.
 
-Common manifest errors you'll see in `errors[]`:
+Schema constraints to keep in mind while authoring:
 
-| Error string (verbatim) | Cause |
+| Field | Constraint |
 | --- | --- |
-| `version must be 1` | Missing or wrong `version` field |
-| `agent.name is required` | The `agent` object is missing or `name` is empty |
-| `agent.name exceeds 100 characters` | Trim the name |
-| `skills exceeds maximum of 10` | More than 10 entries in `skills` |
-| `routes exceeds maximum of 10` | More than 10 entries in `routes` |
-| `tasks exceeds maximum of 20` | More than 20 entries in `tasks` |
-| `routes[i].port reserved` | Used port `18789` |
-| `routes[i].port out of range` | Port outside `1025`-`65535` |
-| `tasks[i].schedule.kind invalid` | Schedule kind isn't `at` / `every` / `cron` |
-| `channels.<channel>.botToken required` | Missing token for initial channel setup |
+| `version` | Must be `1` |
+| `agent` | Required; `agent.name` is required and ≤ 100 chars |
+| `agent.description` | ≤ 10000 chars |
+| `agent.vibe` | ≤ 200 chars |
+| `agent.emoji` | ≤ 32 chars |
+| `skills` | ≤ 10 entries |
+| `routes` | ≤ 10 entries; ports `1025`–`65535`, excluding `18789` |
+| `tasks` | ≤ 20 entries; minimum interval 1 minute |
+| `channels.*.botToken` | Required on initial setup (Slack also requires `appToken`) |
 
 See [Errors](/agents/errors) for the full HTTP status code reference.
 

--- a/agents/models.mdx
+++ b/agents/models.mdx
@@ -1,63 +1,65 @@
 ---
 title: "Models"
-description: "Configure which AI models your agent can use"
+description: "Pick which AI models this agent can use"
 icon: "microchip"
 ---
 
-Each agent can access multiple AI models from different providers. You control which models are available and which one is used by default.
+Each agent has its own list of allowed models, grouped by provider. The default model is what the agent reaches for when nothing else says otherwise; you can also swap models in the middle of a conversation if you want a faster (or smarter) one for a specific turn.
 
 <Frame>
   ![Image](/images/image-34.png)
 </Frame>
 
-## View Available Models
+## What you see
 
-Open your agent → **Models**. You'll see models grouped by provider - only providers you've connected in [Secrets](/agents/secrets) will appear here.
+Open your agent → **Models**. The page lists each connected provider as a separate section. Only providers you've connected in the [Secrets Vault](/agents/secrets) show up here — if you don't see OpenAI, for example, it's because you haven't connected an OpenAI key.
 
-Each provider section shows:
+Inside each provider section:
 
-- Models currently enabled for this agent
-- Which model is set as the default (marked with a **DEFAULT** badge)
-- A **\+ ADD** button to enable more
+- One row per model that's currently enabled
+- A **DEFAULT** badge marks the agent's default model
+- An **×** on a row removes that model from this agent
+- **+ ADD** at the top right of each section lets you enable more models from that provider
 
-## Add a Model
+## Enable a model
 
-1. Click **\+ ADD** in the provider section
-2. Select from available models
-3. The model is now available for this agent
+Click **+ ADD** in the provider section and pick a model from the list. It's now available to this agent — you can call it from chat or set it as default. Removing one with **×** doesn't disconnect the provider, it just narrows the menu.
 
-Your agent can switch between any enabled models during conversations.
+## Set the default
 
-## Set the Default Model
+The default is what gets used when you don't specify a model. Click a model row to set it as default; the **DEFAULT** badge moves.
 
-The default model is what your agent uses unless you specify otherwise. One model will show a **DEFAULT** badge.
+## Switch models mid-conversation
 
-To change it, click the model you want as default and select **Set as Default**.
+On the [Chat](/agents/chat) tab, the **MODEL** dropdown next to the message input lets you pick a model for the next turn. You'd typically reach for this to:
 
-## Remove a Model
+- Use a fast/cheap model for routine questions
+- Bump up to a more capable model for a hard one
+- Compare answers from two models on the same prompt
 
-Click the **×** next to any model to remove it from this agent. You can always add it back later.
+Each response is tagged with the model that produced it, so the conversation stays readable when you switch.
 
-## Switch Models in Chat
+## What models look like in configs
 
-In the chat interface, use the model dropdown in the sidebar to switch between enabled models mid-conversation. This is useful for:
+When you reference a model in code, in `manifest.json`, or in a task payload, the convention is `provider/model`:
 
-- Using a faster model for simple tasks
-- Switching to a more capable model for complex reasoning
-- Testing how different models handle the same prompt
+```text
+anthropic/claude-sonnet-4-6
+openrouter/tencent/hy3-preview
+openai/gpt-5.4
+```
 
-## Supported Models
+The provider prefix tells OpenClaw which connected provider to use. If you give it a model that isn't enabled on this agent, the request falls back to the default.
 
-Available models depend on your connected providers:
+## What's available today
 
-**Anthropic** - Claude Sonnet, Opus, Haiku (e.g., `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`)
+The exact list updates as providers ship. A current snapshot:
 
-**OpenAI Codex** - GPT models (e.g., `gpt-5.4`)
+- **Anthropic** — `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
+- **OpenAI Codex** (subscription) — `gpt-5.4`
+- **OpenRouter** — `auto` (lets OpenRouter pick), plus any specific model on the platform (e.g. `tencent/hy3-preview`)
+- **Venice / Pinata / Custom** — whatever the provider exposes
 
-**OpenRouter** - Access to models from multiple providers
-
-**Venice** - Privacy-focused models
-
-<Note>
-  New models are added regularly. Check the Models section in your agent to see the latest available options.
-</Note>
+<Tip>
+  When you select `auto` on OpenRouter, OpenRouter picks the underlying model for each request. Handy if you don't want to micromanage which model handles what.
+</Tip>

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -1,120 +1,148 @@
 ---
 title: "Overview"
-description: "Deploy hosted OpenClaw agents through Pinata"
+description: "Hosted AI agents that can run code, manage files, and connect to other services"
 icon: "lobster"
 ---
 
-Pinata Agents are hosted [OpenClaw](https://openclaw.org) instances - AI agents that can run code, search the web, manage files, and connect to external services. Each agent runs in its own isolated container with a persistent workspace.
+Pinata Agents gives you a hosted AI agent in its own sandboxed container. The agent has a workspace it can read and write to, a terminal it can run commands in, and connectors for the outside world — chat apps, web servers, scheduled jobs. You talk to it through the dashboard, the CLI, or whichever messaging platform you connect it to.
+
+Under the hood, each agent runs the [OpenClaw](https://openclaw.org) engine. You don't have to know OpenClaw to use one, but if you go deep, that's the project to read.
 
 <Note>
   Agents require a paid Pinata plan. [Upgrade here](https://app.pinata.cloud/billing).
 </Note>
 
-## Get Your First Agent Running
+## Get your first agent running
 
-This takes about 2 minutes. You'll connect an LLM provider, create an agent, and start chatting.
+It takes a couple of minutes. You'll connect an LLM provider, create the agent, and start chatting.
 
-### 1. Add Your API Key
+### 1. Connect an LLM provider
 
-Your agent needs access to an LLM to think and respond. Head to [agents.pinata.cloud/secrets](https://agents.pinata.cloud/secrets) and you'll see cards for supported providers at the top.
+Your agent needs an LLM to think. Go to the [Secrets Vault](https://agents.pinata.cloud/secrets).
 
-Click **Connect** on whichever you use - Anthropic, OpenAI, OpenRouter, or Venice - paste your API key, and save. That's it.
+At the top of that page you'll see a row of provider cards: **Anthropic**, **OpenAI**, **OpenRouter**, **Pinata**, **Venice**, and **Custom**. Click **Connect** on whichever one you use, paste your API key (or run through OAuth if you're using a Claude or Codex subscription), and save.
 
 <Tip>
-  Don't have an API key yet? [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), and [OpenRouter](https://openrouter.ai/) all offer free trial credits.
+  Don't have an API key? [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), and [OpenRouter](https://openrouter.ai/) all offer free trial credits.
 </Tip>
 
-### 2. Create Your Agent
+You can connect more than one provider — useful so you have a fallback if one is down.
 
-Go to [agents.pinata.cloud/agents](https://agents.pinata.cloud/agents) and click **Create Agent**.
+### 2. Create an agent
+
+Head to [My Agents](https://agents.pinata.cloud/agents) and click **Create Agent**.
 
 You have two paths:
 
-**Use a template** if you want something working fast. Templates come pre-configured with skills, settings, and personality - just add your secrets and deploy. Browse templates at [agents.pinata.cloud/templates](https://agents.pinata.cloud/templates).
+- **Start from a template** — fastest. Templates come pre-wired with skills, settings, and a personality. Pick one from the [Marketplace](https://agents.pinata.cloud/marketplace) (others' templates) or [My Templates](https://agents.pinata.cloud/templates) (your own). Add the secrets it needs, deploy.
+- **Build from scratch** — full control. The wizard walks you through naming the agent, picking a personality preset (Atlas, Nova, Sage, or custom), choosing skills, and connecting your LLM provider.
 
-**Build from scratch** if you want full control. The wizard walks you through:
+Either way, the agent takes about 30 seconds to provision. When it's ready you land on its Chat tab.
 
-1. **Identity** - Pick a personality (Atlas, Nova, Sage) or create your own. Give it a name.
-2. **Workspace** - The default includes Node.js, Python, and common tools. Add [skills](/agents/skills) if you want extra capabilities.
-3. **Connect** - Select your LLM provider and add any other API keys your agent needs.
-4. **Deploy** - Hit the button and wait about 30 seconds.
+### 3. Start a conversation
 
-### 3. Start Talking
-
-Once your agent is running, you'll land on its chat interface. Say hello. Ask it to help you with something. It can write code, create files, search the web, and more.
+Say hello. Ask it to write some code, summarize a webpage, or set up a workflow. It can use a terminal, edit files, search the web, and call any skills you've attached.
 
 <Frame>
   ![Image](/images/image-29.png)
 </Frame>
 
-## What's in the Agent Dashboard
+## Finding your way around
 
-Click any agent to open its detail page. Here's what you'll find:
+The sidebar on the left is the same on every page. Top half is the workspace itself; bottom half is account and support.
 
-**Chat** - Your conversation interface with a model switcher and live resource stats in the sidebar.
-
-**Channels** - Connect your agent to Telegram, Slack, or Discord so others can talk to it too.
-
-**Files** - Workspace snapshots, version history, and git access for local editing.
-
-**Skills** - Packages that give your agent new abilities, like IPFS storage or on-chain registration.
-
-**Secrets** - API keys and credentials your agent can access as environment variables.
-
-**Models** - Configure which models your agent can use and set the default.
-
-**Routes** - Expose web servers or APIs running inside your agent to the internet.
-
-**Tasks** - Schedule prompts to run automatically.
-
-### Dev Tools
-
-When you need to debug or dig deeper:
-
-- **[Console](/agents/console)** - Full terminal access to your agent's container
-- **[Logs](/agents/logs)** - Real-time logs with level filtering, search, and export
-- **[Danger](/agents/devtools)** - Agent details, workspace state, configuration, restart, and delete
+| Section | What's in it |
+| --- | --- |
+| **My Agents** | Every agent you've created. Click one to expand its tabs (Chat, Channels, Files, Skills, etc.). |
+| **My Issues** | A kanban board for assigning work to agents. Closed beta — `@pinata.cloud` accounts today. |
+| **Skills Library** | Skills you've installed, plus a community catalog under **Browse ClawHub**. |
+| **Secrets Vault** | All your encrypted credentials, in one place, shared across agents. |
+| **My Templates** | Templates you've created or imported. |
+| **Marketplace** | Published templates from Pinata and other builders, ready to deploy in one click. |
+| **Account** | **Workspaces** (switch teams), **Integrations** (e.g. GitHub OAuth), **Activity** (audit log). |
+| **Support** | Docs, the OpenAPI reference, changelog, and a way to chat with the Pinata team. |
 
 <Tip>
-  Press **⌘K** (or **Ctrl\+K**) anywhere to open the command palette for quick navigation to agents, pages, and actions.
+  **⌘K** (or **Ctrl+K**) opens a command palette for jumping to any agent, page, or action.
 </Tip>
 
-### Working with Git
+## The agent dashboard
 
-Want to edit your agent's workspace locally? Clone it:
+Click any agent and you'll see tabs across the top of the page. Each tab is a slice of how the agent works:
+
+- **Chat** — your conversation with the agent
+- **Channels** — wire it up to Telegram, Slack, or Discord
+- **Files** — workspace snapshot history, content diffs, git URL
+- **Skills** — capabilities attached to this specific agent (pulled from your Skills Library)
+- **Secrets** — provider connections and env vars this agent can see
+- **Models** — which models from your providers it's allowed to use, and which is the default
+- **Routes** — path routes and custom domains for any web service it runs
+- **Tasks** — cron jobs and one-off scheduled prompts
+- **Console** — a terminal inside the container
+- **Logs** — real-time log stream
+- **Danger** — full configuration overview, plus restart and delete
+
+That last one is named "Danger" deliberately — restart and delete live there, but so does most of the inventory data, so it's also the page you'll open when you need to know exactly how an agent is configured.
+
+## Editing the workspace locally
+
+Your agent's workspace is a git repo you can clone and push to.
 
 ```bash
 git clone https://agents.pinata.cloud/v0/agents/{agentId}/git my-agent
 ```
 
-Click **Copy with Token** in the Files section to get the URL with authentication included.
+On the Files tab, **Copy with Token** gives you a URL with authentication built in so you don't have to manage credentials. Edit locally, push, and the agent picks up your changes — the build script (if you've defined one) runs automatically.
 
-## Using the CLI
+See [Files & Snapshots](/agents/snapshots) for the full flow.
 
-Everything in the UI is also available through the [CLI](/tools/cli/agents):
+## Working from the terminal
+
+Everything in the dashboard is in the CLI too:
 
 ```bash
 pinata agents list              # See your agents
 pinata agents create            # Create a new agent
 pinata agents get <agent-id>    # Get agent details
+pinata agents chat <agent-id>   # Talk to it from your terminal
 ```
 
-## Next Steps
+Full reference: [Agents CLI](/tools/cli/agents).
+
+## Going deeper
+
+<CardGroup cols={2}>
+  <Card title="Concepts" icon="compass" href="/agents/concepts">
+    Glossary, file layout, and how the pieces relate
+  </Card>
+
+  <Card title="Manifest reference" icon="file-code" href="/agents/manifest">
+    Every field in `manifest.json`, the source of truth for an agent's config
+  </Card>
+
+  <Card title="HTTP API" icon="plug" href="/agents/api">
+    Auth model and endpoint reference for building against the platform
+  </Card>
+
+  <Card title="Troubleshooting" icon="wrench" href="/agents/troubleshooting">
+    What to do when something doesn't work
+  </Card>
+</CardGroup>
 
 <CardGroup cols={2}>
   <Card title="Templates" icon="grid-2" href="/agents/templates/overview">
-    Deploy a pre-configured agent in one click
+    Deploy a pre-built agent in one click
   </Card>
 
   <Card title="Channels" icon="comments" href="/agents/channels">
-    Let others talk to your agent on Telegram, Slack, or Discord
+    Let people talk to your agent on Telegram, Slack, or Discord
   </Card>
 
   <Card title="Skills" icon="wand-magic-sparkles" href="/agents/skills">
-    Give your agent new abilities
+    Add capabilities — IPFS storage, memory, on-chain identity, more
   </Card>
 
   <Card title="Routes" icon="network-wired" href="/agents/routes">
-    Expose a web app or API to the internet
+    Expose a web app or API from inside the agent
   </Card>
 </CardGroup>

--- a/agents/routes.mdx
+++ b/agents/routes.mdx
@@ -1,102 +1,117 @@
 ---
 title: "Domains & Routes"
 sidebarTitle: "Routes"
-description: "Expose agent services to the internet"
+description: "Expose web services from inside your agent to the internet"
 icon: "network-wired"
 ---
 
-If your agent runs a web server, API, or any other network service, routes let you expose it to the internet. Your agent's container is isolated by default - routes punch a hole through so the outside world can reach your service.
+By default, anything your agent runs on a port stays inside the container — nobody on the outside can reach it. Routes punch a hole through so the outside can.
 
-## When You Need Routes
-
-Common use cases:
-
-- Your agent runs a web app (React, Vue, etc.) and you want users to access it
-- Your agent exposes an API that other services need to call
-- You're running a dev server with hot reload and need external access
-
-If your agent just chats and runs scripts, you probably don't need routes.
+You'd want this if your agent is hosting a web app, an API, or a dev server you want to view in a browser. If your agent just chats and runs scripts, you don't need any of this.
 
 <Frame>
   ![Image](/images/image-35.png)
 </Frame>
 
-{/* Screenshot: Domains & Routes tab showing path routes (PROTECTED) and custom domains (PUBLIC) with PREVIEW buttons */}
+## Two kinds of route
 
-## Add a Route
+Open your agent → **Routes**. There are two sections:
 
-Open your agent → **Routes** → **\+ ADD**.
+- **Path routes** — your service is reachable on the agent's own subdomain, under a path prefix you choose. No DNS work; works immediately.
+- **Custom domains** — your service is reachable on a Pinata-provided subdomain (`name-name-NN.apps.pinata.cloud`) or on your own domain.
 
-You have two options: **Path Route** or **Custom Domain**.
+Click **+ ADD** to add either.
 
-### Path Routes
+## Path routes
 
-Path routes are the simplest option. Your service becomes available at a URL like:
+This is the simplest option. Pick a port and a path; the route becomes available at:
 
 ```text
-https://agents.pinata.cloud/v0/agents/{agentId}/app/...
+https://{agentId}.agents.pinata.cloud/<path>/...
 ```
 
-To set one up:
+Click **+ ADD** → **Path Route**, then fill in:
 
-1. Click **\+ ADD** → **Path Route**
-2. Enter the container port your service runs on
-3. Enter a path prefix (like `/app` or `/api`)
-4. Choose **Public** or **Protected** access
-5. Click **Add Route**
+1. **Container port** — the port your service is listening on inside the agent (e.g. `5173`)
+2. **Path prefix** — the URL path (e.g. `/app`, or `/` for everything)
+3. **Public** or **Protected** access — see below
 
-One thing to know: the path prefix gets stripped before reaching your service. If someone requests `/app/users/123`, your service sees `/users/123`.
+One thing to know: the path prefix is **stripped** before the request hits your service. If someone visits `/app/users/123`, your service sees `/users/123`. Most frameworks let you configure a base path to match — for Vite that's `base: "/app"`.
 
-### Custom Domains
+## Custom domains
 
 <Note>
   Custom domains are currently in beta.
 </Note>
 
-Want a cleaner URL? Custom domains give you either a Pinata subdomain (like `glow-kite-520.apps.pinata.cloud`) or let you use your own domain.
+There are two flavors.
 
-**For a Pinata subdomain:**
+### Pinata-provided subdomain
 
-1. Click **\+ ADD** → **Subdomain** tab
-2. Edit the generated subdomain name if you'd like (a random name is pre-filled)
-3. Enter the container port
-4. Choose **Public** or **Protected** access
-5. Click **Register**
+Easiest. You get a random `name-name-NN.apps.pinata.cloud` subdomain that points at your agent.
 
-**For your own domain:**
+1. **+ ADD** → **Subdomain** tab
+2. Optionally rename the auto-generated subdomain (you can also accept the default)
+3. Set the container port and Public/Protected
+4. **Register** — it's live immediately
 
-1. Click **\+ ADD** → **Custom Domain** tab
-2. Enter your domain (like `app.yourdomain.com`)
-3. Enter the container port
-4. You'll receive a TXT record challenge - add a TXT record at `_pinata-verify.yourdomain.com` with the provided value
-5. Save the domain registration
-6. Add a CNAME record pointing to the target shown after registration
-7. Click **Verify** to confirm ownership and provision SSL
+### Bring your own domain
 
-After you click Verify, Pinata checks your TXT record to confirm you own the domain, then provisions SSL through Cloudflare. This can take a few minutes - your domain will show as "pending" until everything is ready.
+1. **+ ADD** → **Custom Domain** tab
+2. Type your domain (e.g. `app.example.com`)
+3. Pinata gives you a TXT record value — add it as `_pinata-verify.app.example.com` at your DNS provider
+4. Submit the registration
+5. Pinata gives you a CNAME target — add a CNAME from `app.example.com` to that target
+6. Click **Verify**
 
-<Note>
-  The same domain always produces the same challenge token, so you only need to add the TXT record once even if you need to re-verify.
-</Note>
+After Verify, Pinata checks your TXT record, then provisions an SSL certificate through Cloudflare. The domain shows up in the list with a status; once it reads **active**, traffic is flowing.
 
-### Editing and Removing Domains
+DNS propagation and SSL provisioning typically take a few minutes. If your domain stays in a pending state, see [Troubleshooting → Custom domain stuck pending](/agents/troubleshooting#custom-domain-stuck-pending).
 
-Once a custom domain is created, you can update its **target port** and **protected** setting, but you cannot change the domain name or subdomain. To switch domains, delete and recreate.
+### Editing a custom domain
 
-## Protected vs Public
+Once registered, you can change the **target port** and the **Protected** flag. You can't rename the domain — to switch, delete and recreate.
 
-**Protected routes** require a gateway token to access. Use this when you want to control who can reach your service.
+## Public vs Protected
 
-**Public routes** are open to anyone on the internet. Only use this if your service handles its own authentication, or if you genuinely want it public.
+Every route, path or domain, is one or the other.
 
-Both path routes and custom domains default to **public**. Set them to **protected** explicitly if you need access control.
+- **Public** — anyone on the internet can reach it. Use this if your service handles its own auth, or you genuinely want it open.
+- **Protected** — requests must include the agent's gateway token. The token can be in the `Authorization: Bearer` header, a `?token=...` query string, or a `gw_token` cookie. Use this when you want the route locked down with no extra work.
 
 <Warning>
-  Think carefully before making a route public. Anyone can access it.
+  Public means *public*. Think before flipping that switch.
 </Warning>
 
-## Limits
+## Building a web app that works behind a route
 
-- Up to 10 path routes per agent
-- Up to 5 custom domains per agent
-- Ports must be between 1025 and 65535 (port 18789 is reserved)
+Two things have to be true or it won't work, and the fix is almost always one of them:
+
+1. **Your server has to bind to `0.0.0.0`**, not `localhost`. The gateway can't reach `localhost` from outside the process.
+2. **Your dev server has to allow the agent's host**. Vite, Next, etc. check `Host` and reject unknowns by default.
+
+Use the placeholder `__AGENT_HOST__` in config files — it's replaced at runtime with the agent's public hostname. Example for Vite:
+
+```ts
+export default defineConfig({
+  base: "/app",
+  server: {
+    host: "0.0.0.0",
+    allowedHosts: ["__AGENT_HOST__"],
+    hmr: {
+      host: "__AGENT_HOST__",
+      protocol: "wss",
+      clientPort: 443,
+    },
+  },
+});
+```
+
+If a route 404s or 502s after you've set everything up, [Troubleshooting → Routes not working](/agents/troubleshooting#routes) covers the common causes.
+
+## Limits and reserved values
+
+- Up to **10 path routes** per agent
+- Up to **5 custom domains** per agent
+- Container ports must be between `1025` and `65535`. Port `18789` is reserved for the gateway.
+- Subdomains containing the word "pinata" or using reserved suffixes are rejected.

--- a/agents/secrets.mdx
+++ b/agents/secrets.mdx
@@ -1,85 +1,89 @@
 ---
 title: "Secrets"
-description: "Store API keys and credentials securely"
+description: "Where API keys and credentials live"
 icon: "key"
 ---
 
-Your agent needs API keys to talk to LLMs, access external services, and do useful work. Secrets are how you give your agent those keys securely - they're encrypted, never logged, and available to your agent as environment variables.
+Your agent needs credentials — an LLM key, sometimes a bot token or two, maybe a database password. The Secrets Vault is where those live. They're encrypted at rest, never returned by the API after you save them, and injected into the agent as environment variables when its container starts.
 
 <Warning>
-  You can't view secret values after saving them. Make sure you have your credentials stored somewhere safe before adding them here.
+  You can't read a secret's value back once it's saved. Make sure you have it stored somewhere safe before you paste it in here.
 </Warning>
 
 <Frame>
   ![Image](/images/image-33.png)
 </Frame>
 
-## Connect Your LLM Provider
+## Connect a provider
 
-This is the first thing you'll do. Your agent needs at least one LLM provider connected to work.
+This is the first thing to do. Without at least one connected provider, your agent has no LLM to call.
 
-Go to [agents.pinata.cloud/secrets](https://agents.pinata.cloud/secrets). At the top you'll see cards for supported providers:
+Open the [Secrets Vault](https://agents.pinata.cloud/secrets). The row at the top — **AI PROVIDERS** — has a card for each supported provider:
 
-- **Anthropic** - Claude models (API key or Claude subscription)
-- **OpenAI** - GPT models (API key or Codex subscription)
-- **OpenRouter** - Access multiple providers through one API
-- **Venice** - Privacy-focused AI
+| Provider | How it connects |
+| --- | --- |
+| **Anthropic** | API key, or OAuth into a Claude subscription |
+| **OpenAI** | API key, or OAuth into a Codex subscription |
+| **OpenRouter** | API key |
+| **Pinata** | Pinata-hosted inference |
+| **Venice** | API key (privacy-focused) |
+| **Custom** | Any OpenAI-compatible endpoint |
 
-Click **Connect** on whichever you use, paste your API key, and save. That's the minimum you need to run an agent. Connected providers show a green "Connected" status on their card.
+Cards that aren't connected show a **CONNECT** button. Click it, follow the prompts, save. The card flips to **Connected**.
 
-<Tip>
-  Anthropic and OpenAI also support subscription-based access (Claude and Codex subscriptions). These connect via OAuth instead of an API key.
-</Tip>
+You can connect more than one provider — useful for fallbacks, or for routing different agents to different LLMs.
 
-## Add Other Secrets
+## Add other secrets
 
-For any other API key, token, or credential your agent needs:
+For everything that isn't a provider key — bot tokens, third-party API keys, database URLs — use **New Secret** at the top right of the Vault.
 
-1. Click **New Secret** (use the dropdown to choose between secret and variable)
-2. Enter a name (this becomes the environment variable, like `TELEGRAM_BOT_TOKEN`)
-3. Enter the value
-4. Save
+The dialog asks for:
 
-Your agent can now access this as `process.env.TELEGRAM_BOT_TOKEN` (or the equivalent in Python).
+1. A **name** (this is the environment variable, like `TELEGRAM_BOT_TOKEN`)
+2. A **value**
+3. A **type** — `secret` or `variable`
 
-### Variables vs Secrets
+Save. Your agent will see it as `process.env.TELEGRAM_BOT_TOKEN` (or the equivalent in Python, Bash, etc.) on next restart.
 
-**Secrets** are encrypted - use them for API keys, tokens, passwords.
+### Secret vs variable
 
-**Variables** are not encrypted - use them for non-sensitive config like feature flags or URLs.
+Both become env vars. The difference is encryption:
 
-Select **Variable** from the **New Secret** dropdown if you don't need encryption.
+- **Secret** — encrypted at rest, never returned in API responses. Use for anything sensitive: keys, tokens, passwords.
+- **Variable** — stored as plaintext, value returned in listings. Use for non-sensitive config — public URLs, feature flags.
 
-### Importing from .env
+If you're unsure, choose **secret**. There's no downside.
 
-Already have a `.env` file? Click **Import .env file** to add everything at once.
+### Importing a `.env`
 
-## Give Your Agent Access
+Have a `.env` file already? The New Secret menu has an **Import .env** option that adds every line in one go.
 
-Secrets live in your vault, but you need to explicitly attach them to each agent that should use them.
+## Make a secret available to an agent
 
-**When creating an agent:** You'll add secrets in Step 3 (Connect).
+Saving a secret in the Vault doesn't automatically give it to every agent. You attach secrets per-agent — that way you can give different agents different credentials.
 
-**For existing agents:** Open the agent → **Secrets** → click **\+ ADD** to attach from your vault.
+- **When creating an agent**: step 3 of the wizard ("Connect") lets you pick which secrets to attach.
+- **For an existing agent**: open the agent → **Secrets** → **+ ADD** and pick from your Vault.
 
-On the agent's Secrets tab you'll see your connected AI providers at the top (showing whether you're using an API key or a subscription like Claude or Codex), followed by any other variables and secrets you've attached.
+On the agent's Secrets tab you'll see two sections:
+
+1. **AI Providers** — the providers you've connected. Each card shows whether it's an `API KEY` connection or a `CODEX SUBSCRIPTION` / `CLAUDE SUBSCRIPTION`.
+2. **Variables and Secrets** — the non-provider secrets you've attached.
+
+At the bottom of the same page is the **Gateway Token** — the credential other tools use to talk to *this specific agent*. See [HTTP API → Gateway token](/agents/api#gateway-token) for what to do with it.
 
 <Note>
-  If you add or update a secret on a running agent, you'll need to restart it for the change to take effect.
+  When you add or update a secret on a running agent, restart the gateway so the agent picks up the new value. The Danger tab shows a per-secret **Synced** indicator so you can tell whether you've already done that.
 </Note>
 
-## Updating and Removing
+## Updating, removing, and edge cases
 
-Click the **...** menu on any secret to update or delete it.
+- Click the **⋯** menu on any secret to update its value or delete it.
+- You can't delete a secret that's still attached to an agent — detach it first, or you'll get a `409 Conflict`.
+- Updating a value doesn't roll out automatically — restart the gateway.
+- Attaching two credentials for the same provider (say, an Anthropic API key *and* a Claude subscription) returns a `409 Conflict`. Pick one.
 
-A few things to know:
-
-- You can't delete a secret that's still attached to an agent - detach it first
-- Updated secrets require an agent restart - each secret on the Danger page shows a "Synced" status so you can tell whether the running agent has picked up the latest value
-- There's no way to view the current value (that's the point)
-- Your Secrets Vault shows which agents each secret is attached to, so you can see at a glance where credentials are in use
-
-## Using the CLI
+## From the CLI
 
 ```bash
 pinata agents secrets list                  # See your secrets
@@ -87,9 +91,9 @@ pinata agents secrets add <name> <value>    # Add one
 pinata agents secrets delete <name>         # Remove one
 ```
 
-## How Secrets Are Protected
+## How secrets are protected
 
-- Encrypted at rest with AES-GCM
-- Unique key derived per user
-- Values never returned by the API
-- Injected as environment variables at runtime, never written to disk
+- Encrypted with AES-GCM using a key derived per user
+- Values are never returned by the API after creation
+- Injected as environment variables at container start, never written to disk
+- The per-agent gateway token is generated automatically and can be rotated from the Danger tab

--- a/agents/skills.mdx
+++ b/agents/skills.mdx
@@ -1,64 +1,65 @@
 ---
 title: "Skills"
-description: "Extend agent capabilities with reusable packages"
+description: "Reusable capability packages you can attach to an agent"
 icon: "wand-magic-sparkles"
 ---
 
-Skills give your agent new abilities. Want your agent to store files on IPFS? There's a skill for that. Need it to remember things between conversations? There's a skill for that too.
+Skills are how you teach an agent new tricks without rewriting it. A skill is a folder of files — code, instructions, sometimes a `.env.example` listing what credentials it needs. When you attach a skill to an agent, those files land in the agent's workspace and the agent can use them.
 
-Think of skills as plugins - pre-packaged code and instructions that teach your agent how to do something specific.
+There are two views to keep separate in your head:
+
+- The **Skills Library** in the sidebar — the catalog of skills installed in your account. This includes the ones Pinata publishes and any you've added from the community or your own folder.
+- A specific agent's **Skills tab** — which subset of the library is actually attached to *this* agent. Installing a skill in the Library doesn't attach it; attachment happens per-agent.
 
 <Frame>
   ![Image](/images/image-32.png)
 </Frame>
 
-## Browse Available Skills
+## Find a skill
 
-Head to [agents.pinata.cloud/skills](https://agents.pinata.cloud/skills) to see what's available.
+Open the **Skills Library** in the sidebar.
 
-The **All | Installed** tab shows skills in your library. Switch to **Browse ClawHub** to find community skills made by others.
+Two tabs at the top:
 
-### Official Skills from Pinata
+- **All | Installed** — skills already in your library
+- **Browse ClawHub** — the community catalog
 
-These are built and maintained by the Pinata team (look for the verified badge):
+Search by name in either tab. Each card shows the skill name, author, install count, version, and a CID prefix. Pinata-built skills (like `@pinata/api`) carry a verified badge and show up in both tabs.
 
-- **@pinata/api** - Store and retrieve files from IPFS, use gateways, run vector searches
-- **@pinata/memory-salience** - Help your agent remember what matters and forget what doesn't
-- **@pinata/sqlite-sync** - SQLite database with automatic Pinata backup
-- **@pinata/paraspace** - Organize your agent's workspace using the PARA method
-- **@pinata/erc-8004** - Register your agent on-chain
+### Skills Pinata maintains
 
-### Community Skills
+- **`@pinata/api`** — store and retrieve files on IPFS, use gateways, run vector searches, sign x402 payments
+- **`@pinata/erc-8004`** — register your agent on-chain and verify other agents (ERC-8004)
+- **`@pinata/memory-salience`** — let your agent remember what matters across conversations
+- **`@pinata/paraspace`** — organize the workspace with the PARA method
+- **`@pinata/sqlite-sync`** — a SQLite database with automatic Pinata backup and CID-chained history
+- **`@pinata/platform`** — the agent can call back into the platform (install skills, set secrets, manage tasks) without ever seeing your Pinata JWT. Bundled by default.
 
-The **Browse ClawHub** tab has skills for all sorts of things - Obsidian integration, self-improvement loops, API gateways, and more. Each skill card shows the author, download count, star count, and current version.
+## Install a skill
 
-Pinata-verified skills (like `@pinata/api`) show a verified badge and appear in both your library and ClawHub. Community skills are contributed by users and sorted by popularity.
+Click a card to see its description, files, and required env vars. **Install** adds it to your library. From there, you can attach it to as many agents as you like.
 
-Use the search box to find skills by name.
+Installing alone doesn't change anything about your running agents — you still need to attach it.
 
-## Install a Skill
+## Attach a skill to an agent
 
-Click any skill to see its details - description, required secrets, files, and version history. If it looks useful, click **Install**. The skill gets added to your library.
+- **When creating a new agent**: step 2 of the wizard lets you pick skills from your library.
+- **For an existing agent**: open the agent → **Skills** → **+ ADD** and pick from your library.
 
-Installing doesn't attach the skill to any agent - it just makes it available to use.
+Attaching copies the skill's files into the agent's workspace under `workspace/skills/<skill-name>/`. The agent reads from there.
 
-## Attach a Skill to an Agent
+If the skill declares required env vars in a `.env.example`, the Skills tab flags any that aren't set on the agent. Add the missing values in the [Secrets Vault](/agents/secrets) and attach them, then restart the gateway.
 
-Once a skill is in your library, you can attach it to any of your agents.
+<Tip>
+  Detaching a skill removes its files from the agent's workspace but keeps the skill installed in your library. You can re-attach later.
+</Tip>
 
-**For new agents:** Add skills in Step 2 (Workspace) of the creation wizard.
+## Slugs vs CIDs
 
-**For existing agents:** Open the agent → **Skills** → **\+ ADD** → pick from your library.
+Anywhere you reference a skill — in the CLI, in [`manifest.json`](/agents/manifest), in API calls — you can use either form:
 
-When you attach a skill, its files get copied into your agent's workspace. Your agent can then read the skill's instructions and use its code.
-
-{/* Screenshot: Skill detail drawer showing description, required secrets, file browser, and version history */}
-
-Click any attached skill to open its detail drawer - you'll see the description, required secrets, a file browser, and version history.
-
-### Referencing Skills by Slug or CID
-
-When you add skills through the CLI or in a template's `manifest.json`, you can reference them by their **ClawHub slug** (like `@pinata/api`) or their **IPFS CID**. Slugs are the easier option for marketplace skills - they always resolve to the latest version.
+- **Slug** (`@pinata/api`) — always resolves to the latest published version. Easiest for templates and shared configs.
+- **IPFS CID** (`bafybeicglyjdb6w...`) — pins one specific version. Use when you want byte-stable behavior or you're using a self-hosted skill not on ClawHub.
 
 ```json
 "skills": [
@@ -67,30 +68,22 @@ When you add skills through the CLI or in a template's `manifest.json`, you can 
 ]
 ```
 
-CIDs are useful when you want to pin a specific version or use a self-hosted skill that isn't on ClawHub.
+## Versions and updates
 
-<Tip>
-  Detaching a skill removes its files from the agent but keeps the skill in your library. You can always reattach it later.
-</Tip>
+Skills follow semver. Each card shows the current version (`v1.0.0`, etc.).
 
-## Skill Versions
+- **Update** — if a newer version exists, the Skills tab will show an update available. Update from there. For ClawHub skills, this pulls the latest published version.
+- **Roll back** — open a skill's version history and pick an earlier version. Internally that re-pins to that version's CID.
 
-Skills use version numbers (like `v1.0.0`) so you can track changes over time. You'll see the current version badge on each skill in your library and on attached skills.
+If you're building automation, you can also check for updates via the API: `GET /v0/agents/{agentId}/skills/updates`.
 
-### Updating
+## Publishing your own
 
-Open your agent → **Skills** and click into a skill to see its version history. If a newer version exists, you can update to get the latest code and instructions. For ClawHub skills, updates pull the latest version from the marketplace automatically.
+Have something useful? Package it as a skill.
 
-### Rolling Back
-
-If an update causes issues, open the skill's version history and select an earlier version to roll back to.
-
-## Create Your Own Skill
-
-Have something useful your agent knows how to do? Package it as a skill.
-
-1. Create a folder with your skill files
-2. Add a `SKILL.md` file with YAML frontmatter including `name`, `description`, and optionally metadata (JSON with required env vars)
+1. Put your files in a folder
+2. Add a `SKILL.md` with YAML frontmatter — at minimum, `name` and `description`
+3. Optional: a `.env.example` declaring required env vars (the UI will read this and flag missing values when someone attaches it)
 
 ```markdown
 ---
@@ -100,24 +93,26 @@ description: What this skill does
 
 # My Skill
 
-Instructions your agent should follow when using this skill.
+Instructions the agent should follow when using this skill.
 ```
 
-3. In the Skills Library, click **Upload Skill**
-4. Choose your folder, enter a name and optional description
-5. Click **Upload & Register**
+In the Skills Library, click **Upload Skill**, choose your folder, give it a name and description, then **Upload & Register**.
 
 <Note>
-  Skills are uploaded to the public IPFS network. Don't include secrets or sensitive code.
+  Skill folders are pinned to public IPFS. Don't include secrets or anything you wouldn't paste into a Gist.
 </Note>
 
-## Using the CLI
+## From the CLI
 
 ```bash
 pinata agents skills list              # See your library
 pinata agents skills create <path>     # Upload a new skill
+pinata agents clawhub list             # Browse the community catalog
+pinata agents clawhub install <slug>   # Install a community skill
 ```
 
 ## Limits
 
-You can attach up to 10 skills per agent. Skill names can only contain letters, numbers, hyphens, and underscores.
+- Up to **10 skills** attached per agent
+- Skill names: letters, numbers, hyphens, underscores
+- Folder size limits follow Pinata's IPFS upload limits

--- a/agents/snapshots.mdx
+++ b/agents/snapshots.mdx
@@ -1,90 +1,97 @@
 ---
 title: "Files & Snapshots"
 sidebarTitle: "Files"
-description: "Version history and git access for your agent's workspace"
+description: "Browse, version, and edit your agent's workspace"
 icon: "folder-open"
 ---
 
-Snapshots capture the state of your agent's workspace. They're created automatically as your agent works, and you can restore to any previous state if something goes wrong.
+The Files tab gives you three things: a snapshot history of the agent's workspace, content diffs so you can see what changed between snapshots, and a git URL so you can clone the workspace locally and edit it like any other repo.
 
 <Frame>
   ![Image](/images/image-39.png)
 </Frame>
 
-## How Snapshots Work
+## Workspace Snapshots
 
-Your agent's workspace is automatically captured every minute when changes are detected. Each snapshot includes:
+Every minute or so, when the workspace has changed, Pinata captures a snapshot. Each snapshot is the entire workspace pinned to IPFS as a single CID — your full file tree at that point in time, immutable.
 
-- All files in the workspace
-- A content identifier (CID) for the snapshot
-- Timestamp of when it was captured
+The summary card at the top shows:
 
-Open your agent → **Files** to see:
+- **Status** — `Live`, plus how long ago the workspace last synced
+- **Lifecycle Scripts** — whether `build` and `start` are configured (and their run state if they are)
+- **Scheduled Tasks** — whether any tasks are set up
+- **Files** — total file count and the current snapshot CID
 
-- **Status** - Whether the workspace is live and when it last synced
-- **Lifecycle Scripts** - Build/start script status
-- **Scheduled Tasks** - Task configuration status
-- **Files** - Total file count with the current snapshot CID
+Below the summary is the snapshot list — newest at the top, labeled `LATEST`, `V9`, `V8`, and so on. Click any version to expand its **Content Diff** — a file-by-file view of what changed since the previous snapshot, rendered as either a unified or side-by-side diff.
 
-## Restore to a Previous State
+Common file you'll see diffs for: `manifest.json`. See the [manifest reference](/agents/manifest) for what every field means.
 
-If your agent's workspace gets into a bad state, you can restore from any previous snapshot:
+## Restore an older snapshot
 
-1. Open **Files**
-2. Browse the snapshot history
-3. Click on a snapshot to see what changed
-4. Select **Restore** to roll back to that state
+If a recent change broke something, you can roll back.
+
+1. Find the snapshot you want in the list
+2. Open it
+3. **Restore**
+
+Under the hood this runs a `git --hard` reset to the commit associated with that snapshot. The current workspace is replaced — anything that hadn't been captured into a snapshot yet is lost.
 
 <Warning>
-  Restoring replaces your current workspace with the snapshot contents. Any changes since that snapshot will be lost.
+  Restore is destructive. Snapshot the current state first if you might want to come back to it.
 </Warning>
 
-## Git Access
+## Force a snapshot now
 
-You can clone your agent's workspace locally, make changes, and push them back. This is useful for:
+Snapshots run on their own, but you can trigger one immediately:
 
-- Editing files in your preferred IDE
-- Making bulk changes
-- Version controlling your agent's configuration
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/snapshots/sync
+```
 
-### Clone the Workspace
+The same endpoint with `GET` returns sync status — whether storage is configured, when it last synced, and a human-readable message.
+
+## Editing the workspace locally
+
+The workspace is a git repo, served by Pinata. Clone, edit in your IDE, commit, push.
 
 ```bash
 git clone https://agents.pinata.cloud/v0/agents/{agentId}/git my-agent
 ```
 
-Click **Copy with Token** to get the URL with authentication included.
+Click **Copy with Token** in the Files tab and you get a URL with the gateway token already baked in as HTTP Basic auth — no credential setup, just clone and go.
 
-The "Copy with Token" button embeds your gateway token directly in the URL so git can authenticate automatically.
-
-### Make Changes and Push
+### Pushing changes
 
 ```bash
-# Edit files in workspace/ and skills/
-git add -A && git commit -m "my changes"
+# edit files in workspace/ or skills/
+git add -A
+git commit -m "tweak the workspace"
 git push
 ```
 
-### Pull Changes Made by the Agent
+When you push, the server commits any pending agent-side changes first, then applies your push on top. That means your push automatically picks up anything the agent has been writing.
 
-Your agent modifies its own workspace as it works. Pull to sync those changes locally:
+After a push, the agent's `build` script (if you've set one) runs automatically. Check the **Lifecycle Scripts** row to watch its status. Details: [Manifest → Scripts](/agents/manifest#scripts).
+
+### Pulling agent-side changes
+
+Your agent writes to the same workspace as it works. To sync that locally:
 
 ```bash
 git pull
 ```
 
-### Set Up Persistent Credentials
+### Persistent credentials
 
-Tired of copying the token each time? Set up git credentials to remember your authentication:
+Copying the tokened URL every time gets old. Expand **Setup Persistent Credentials** in the Files tab and follow the instructions — git stores the credentials, future operations authenticate automatically.
 
-1. In the Files section, expand **Setup Persistent Credentials (Skip Token Copy Each Time)**
-2. Follow the instructions to configure git credential storage
-3. Future git operations will authenticate automatically
+## Reading or uploading files programmatically
 
-<Tip>
-  When you push, the server first commits any pending workspace changes made by the agent before applying your push. This means your push automatically picks up any uncommitted agent-side changes.
-</Tip>
+Two endpoints, both on the agent's subdomain:
 
-<Tip>
-  After pushing changes, your agent's build script (if configured) will run automatically. Check the Files section to see the lifecycle script status.
-</Tip>
+- `GET /v0/agents/{agentId}/files?path=<path>` — read any file inside the container
+- `POST /v0/agents/{agentId}/files/upload` — upload a base64-encoded file into `<workspace>/uploads/`
+
+Both require auth (Pinata JWT or gateway token). See [API → Files](/agents/api#files).

--- a/agents/tasks.mdx
+++ b/agents/tasks.mdx
@@ -1,100 +1,115 @@
 ---
 title: "Tasks"
-description: "Schedule prompts to run automatically"
+description: "Run prompts on a schedule"
 icon: "clock"
 ---
 
-Tasks let you schedule prompts that run automatically - on a schedule, at a specific time, or on a recurring interval. Use them for daily check-ins, periodic reports, automated workflows, or anything else you want your agent to do without you having to ask.
+Tasks are scheduled prompts. The agent runs them automatically — every Monday morning, every six hours, once next Tuesday at 2pm, whatever you set. Use them for daily check-ins, periodic reports, automation triggered by time rather than by a message.
 
 <Frame>
   ![Image](/images/image-36.png)
 </Frame>
 
-## Create a Task
+## Create a task
 
-Open your agent → **Tasks** → **\+ ADD**.
+Open your agent → **Tasks** → **+ ADD**.
 
-You'll configure:
+The dialog asks for:
 
-1. **Name** - What to call this task
-2. **Schedule** - When it runs
-3. **Prompt** - What to tell your agent
-4. **Delivery** - Where to send the response (optional)
+1. **Name** — anything readable, e.g. `daily-check-in`
+2. **Schedule** — when it runs
+3. **Prompt or system event** — what gets delivered to the agent
+4. **Delivery (optional)** — where the response goes if you want it to leave the agent
 
-### Schedule Types
+That's it. Save and the task starts running on the schedule.
 
-**Cron expression** - Standard cron syntax for complex schedules.
+## Schedule types
 
-```text
-0 9 * * *      # Every day at 9am
-0 */6 * * *    # Every 6 hours
-0 9 * * 1-5    # Weekdays at 9am
-```
+You have three choices for `schedule.kind`:
 
-**Interval** - Run every N minutes/hours.
+- **Cron** — standard cron expression. Most flexible.
 
-**One-time** - Run once at a specific date and time.
+  ```text
+  0 9 * * *      # Every day at 9am
+  0 */6 * * *    # Every six hours
+  0 9 * * 1-5    # Weekdays at 9am
+  ```
 
-You can also set a timezone so schedules run at the right local time.
+- **Every** — run every N milliseconds. Set `staggerMs` if you want to randomize the start offset so multiple tasks don't fire at the same instant.
 
-### Prompt
+- **At** — run once at a specific ISO timestamp.
 
-This is what your agent receives when the task runs. Write it like you're sending a message:
+You can set a timezone (`tz`) so cron respects DST and local time. Minimum interval across all kinds is 1 minute — anything tighter is rejected.
 
-- "Check my portfolio and summarize any significant changes"
-- "Review yesterday's logs and flag anything unusual"
-- "Generate the weekly status report"
+## What gets delivered
 
-You can optionally specify which model to use and a timeout.
+Two payload kinds:
 
-### Message Type
+- **`agentTurn`** (default) — your task fires a chat message. The agent treats it like a regular conversation turn. You can pin a specific `model`, toggle reasoning on or off via `thinking`, and set a `timeoutSeconds`.
 
-Tasks can deliver prompts in two ways:
+  Good prompts to schedule:
+  > "Check my portfolio and summarize anything that moved more than 5% today."
+  >
+  > "Generate the weekly status report from the work log."
 
-- **Agent Message** - The default. Your prompt is delivered as a chat message. Use this for most tasks.
-- **System Event** - Delivered as a system-level event rather than a chat message. Use this for heartbeat checks or maintenance tasks.
+- **`systemEvent`** — fires a system event instead. The agent sees it as a non-conversational trigger. Useful for heartbeats, periodic maintenance, or anything you don't want polluting the chat history.
 
-### Delivery
+## Where the response goes
 
-By default, task results stay in your agent's conversation history. But you can also:
+By default, the response lands back in the agent's main conversation. If you want it to go somewhere else:
 
-**Announce to a channel** - Send the response to Telegram, Slack, or Discord. Useful for alerts or reports you want pushed to you.
+- **Announce to a channel** — send the response to Telegram, Slack, or Discord. Set `delivery.mode` to `announce`, plus a channel and recipient. Good for alerts or daily standups.
 
-**Webhook** - POST the response to a URL. Useful for integrations with other systems.
+  ```json
+  "delivery": { "mode": "announce", "channel": "telegram", "to": "123456789" }
+  ```
 
-## Managing Tasks
+- **Webhook** — POST it to a URL. Good for hooking into other services.
 
-Your tasks list shows each task with its schedule and status.
+  ```json
+  "delivery": { "mode": "webhook", "to": "https://example.com/hook" }
+  ```
 
-**Run now** - Trigger a task immediately without waiting for the schedule.
+Set `bestEffort: true` in delivery if you'd rather swallow a delivery failure than mark the whole run as failed.
 
-**Enable/disable** - Pause a task without deleting it.
+## Sessions: main vs isolated
 
-**Edit** - Change the schedule, prompt, or delivery settings.
+A task can run in the agent's main conversation (so its output is part of the running chat history) or in an isolated session of its own. Pick one with `sessionTarget`:
 
-**Delete** - Remove the task entirely.
+- `main` — output joins the live conversation
+- `isolated` — one-off session that doesn't touch the main thread. Good for batch jobs and webhook-style work.
 
-### Run History
+## Wake mode
 
-Click a task to see its run history - when it ran, whether it succeeded, and what the agent responded.
+`wakeMode` controls timing:
 
-## Using the CLI
+- `now` (default) — fire the task at the scheduled time, even if the agent is busy
+- `next-heartbeat` — wait for the next heartbeat tick. Useful for low-priority background work.
+
+## Managing tasks
+
+Each task in the list has:
+
+- **Run now** — fire it immediately, doesn't affect the schedule
+- **Enable / disable** — pause without deleting
+- **Edit** — change schedule, prompt, or delivery
+- **Delete** — remove it
+- **Runs** — open the run history
+
+Run history shows what fired and when, and whether each run succeeded.
+
+## From the CLI
 
 ```bash
-# List tasks
 pinata agents tasks list <agent-id>
-
-# Create a task
 pinata agents tasks create <agent-id>
-
-# Run a task now
 pinata agents tasks run <agent-id> <task-id>
-
-# Delete a task
 pinata agents tasks delete <agent-id> <task-id>
 ```
 
-## Limits
+## Limits and gotchas
 
-- Up to 20 tasks per agent
-- Minimum interval is 1 minute
+- **20 tasks** per agent
+- Minimum interval **1 minute**
+- A task that runs longer than `timeoutSeconds` (or 5 minutes if unset) is cancelled and marked failed
+- Tasks survive agent restarts. Schedules that would have fired during downtime are skipped, not queued.

--- a/agents/templates/creating.mdx
+++ b/agents/templates/creating.mdx
@@ -4,7 +4,9 @@ description: "Share your agent configuration as a template"
 icon: "hammer"
 ---
 
-Templates let you package an agent configuration for reuse or sharing. This guide walks through creating a template, testing it by deploying your own agent, and optionally submitting it to the marketplace.
+Templates let you package an agent configuration for reuse or sharing. This guide walks through the workflow: clone the starter, customize files, deploy from your template to test, and (optionally) submit it to the marketplace.
+
+For the full `manifest.json` field reference, see the [manifest reference](/agents/manifest).
 
 <Card title="Reference Template" icon="github" horizontal href="https://github.com/PinataCloud/agent-template">
   Clone this starter repo to create your own template.
@@ -22,7 +24,7 @@ cd my-template
 Your repository should have this structure:
 
 ```text
-manifest.json                # Agent config with all options
+manifest.json                # Agent config - see /agents/manifest
 README.md                    # Description shown in marketplace listing
 workspace/
   BOOTSTRAP.md               # First-run conversation guide (self-deletes after setup)
@@ -34,21 +36,23 @@ workspace/
   HEARTBEAT.md               # Periodic tasks (empty by default)
 ```
 
-## Configure manifest.json
+## Configure `manifest.json`
 
-The manifest defines your agent's identity, required secrets, skills, and behavior. It includes a `_docs` block documenting every field.
+The manifest defines your agent's identity, required secrets, skills, scripts, routes, channels, tasks, and marketplace metadata. The starter ships with a `_docs` block documenting every field inline.
 
 | Section | What it does |
 | --- | --- |
 | `agent` | Name, description, vibe, emoji |
 | `model` | Default AI model |
 | `secrets` | Encrypted API keys and credentials |
-| `skills` | Attachable skill packages - use ClawHub slugs (e.g. `@pinata/api`) or CIDs (max 10) |
+| `skills` | Attachable skill packages - ClawHub slugs (e.g. `@pinata/api`) or CIDs (max 10) |
 | `tasks` | Cron-scheduled prompts (max 20) |
-| `scripts` | Lifecycle hooks - `build` runs after git push, `start` runs on agent boot |
+| `scripts` | Lifecycle hooks - `build` runs after deploy/push, `start` runs on agent boot |
 | `routes` | Port forwarding for web apps/APIs (max 10) |
 | `channels` | Telegram, Discord, Slack configuration |
 | `template` | Marketplace listing metadata |
+
+See the [manifest reference](/agents/manifest) for every field's type, defaults, and limits.
 
 <Warning>
   Remove the `_docs` block before submitting to the marketplace.
@@ -56,15 +60,17 @@ The manifest defines your agent's identity, required secrets, skills, and behavi
 
 ### Skills
 
-List the skills your agent should have. Use ClawHub slugs (like `@pinata/api`) for marketplace skills - they'll automatically resolve to the latest version when someone deploys your template. You can also use IPFS CIDs if you want to pin a specific version.
+List the skills your agent should have. Use ClawHub slugs (like `@pinata/api`) for community skills - they'll automatically resolve to the latest version when someone deploys your template. Use IPFS CIDs if you want byte-stable behavior.
 
 ### Example
 
-Here's a complete manifest that includes secrets, skills, lifecycle scripts, a web route, and a daily scheduled task:
+A complete manifest that includes secrets, skills, lifecycle scripts, a web route, and a daily scheduled task:
 
 ```json
 {
+  "$schema": "https://agents.pinata.cloud/schemas/manifest.v1.json",
   "version": 1,
+  "engine": "openclaw",
   "agent": {
     "name": "Useful Assistant",
     "description": "Personal AI helper with file reading, web search, and memory management",
@@ -127,7 +133,7 @@ If your agent runs a server, API, or frontend dev server, add two things to `man
 1. **`scripts`** - lifecycle hooks that install deps and start the server
 2. **`routes`** - port forwarding rules that expose the server to the internet
 
-Example from a Vite \+ React agent:
+Example from a Vite + React agent:
 
 ```json
 {
@@ -143,12 +149,12 @@ Example from a Vite \+ React agent:
 
 **Important details:**
 
-- **`build`** - Runs once after deploy or git push (e.g. `npm install`, compile). Executes from `/home/node/clawd`. Output logged to `/tmp/user-build.log`. Max 5 min timeout. If build fails, start does not run.
+- **`build`** - Runs once after deploy or git push (e.g. `npm install`, compile). Executes from `/home/node/clawd`. Output logged to `/tmp/user-build.log`. 5 min timeout. If build fails, start does not run.
 - **`start`** - Launches a long-running background process after build completes (e.g. a web server). Executes from `/home/node/clawd`. Output logged to `/tmp/user-start.log`. Runs detached so it survives the runner exiting.
-- **Retry scripts** - If you need to re-run the build/start lifecycle (e.g. after pushing changes), use the **Retry Scripts** option in your agent's settings or call the API endpoint.
+- **Retry scripts** - To re-run the build/start lifecycle (e.g. after pushing changes that didn't trigger a build), use the **Retry Scripts** action on the Danger tab or call `POST /v0/agents/{agentId}/scripts/retry`.
 - Your server **must bind to `0.0.0.0`**, not `localhost`, or it won't be reachable
-- Set `protected: false` for public routes, or `true` (default) to require auth
-- Use `__AGENT_HOST__` as a placeholder in config files - it gets replaced at runtime with the agent's public hostname
+- Set `protected: false` for public routes, or `true` to require a gateway token
+- Use `__AGENT_HOST__` as a placeholder in config files - replaced at runtime with the agent's public hostname
 - For WebSocket/HMR setups (e.g. Vite), connect via WSS on port 443 through `__AGENT_HOST__`
 
 Example Vite config using the host placeholder:
@@ -170,7 +176,7 @@ export default defineConfig({
 
 ## Deploy From Your Template
 
-You can deploy an agent from your template before submitting it to the marketplace. This lets you test and iterate on your template.
+You can deploy an agent from your template before submitting it to the marketplace. This is the fastest way to iterate.
 
 **Via the UI:**
 
@@ -197,7 +203,7 @@ Share your template with the community by submitting it for review.
 
 **Via the UI:**
 
-1. Go to [agents.pinata.cloud/templates/submit](https://agents.pinata.cloud/templates/submit)
+1. Go to [My Templates](https://agents.pinata.cloud/templates) → **+ New Template**
 2. Enter your public repository URL
 3. Click **Validate** to check for required files
 4. Review the parsed manifest and workspace files
@@ -218,12 +224,12 @@ pinata agents templates submit https://github.com/user/my-template --branch deve
 
 Template status progression:
 
-- **draft** → **pending\_review** → **published** (or **rejected**)
+- **draft** → **pending_review** → **published** (or **rejected**)
 - Published templates can be **archived** (soft-deleted) and resubmitted later
 
 ## Managing Submissions
 
-Track and update your templates in [**My Templates**](https://agents.pinata.cloud/templates?tab=mine) or via CLI:
+Track and update your templates in [**My Templates**](https://agents.pinata.cloud/templates) or via CLI:
 
 ```bash
 # List your submissions
@@ -235,3 +241,9 @@ pinata agents templates update <template-id>
 # Archive a submission
 pinata agents templates delete <template-id>
 ```
+
+## Paid Templates
+
+Templates submitted with a paid tier use x402 micropayments for one-time purchase. Buyers pay before deploy; once paid, the template behaves like any other in their account.
+
+Mark a template as paid in the `template` block of `manifest.json` - see the [manifest reference](/agents/manifest#template) for the full schema.

--- a/agents/templates/overview.mdx
+++ b/agents/templates/overview.mdx
@@ -9,38 +9,37 @@ icon: "grid-2"
   Templates are currently in beta.
 </Note>
 
-Templates are the fastest way to get a working agent. Instead of configuring everything yourself, pick a template that does what you need - it comes with the right skills, settings, and personality already set up. Just add your API keys and deploy.
+Templates are the fastest path to a working agent. Instead of configuring everything yourself, you pick a template that does what you need — it ships with the right skills, settings, and personality already in place. You add your API keys, and you deploy.
 
 <Frame>
   ![Image](/images/image-25.png)
 </Frame>
 
-## Find a Template
+## Where to look
 
-Browse templates in two places:
+Two places, depending on what you're after:
 
-[**Marketplace**](https://agents.pinata.cloud/marketplace) - Published templates ready to deploy. Filter by category (e.g., General) or search by name. Featured templates appear at the top.
+- [**Marketplace**](https://agents.pinata.cloud/marketplace) — every published template, from Pinata and from other builders. Filter by category, engine, or tags. Featured templates float to the top. Some are paid; those use x402 micropayments and you complete the purchase in flow.
+- [**My Templates**](https://agents.pinata.cloud/templates) — templates you've created, submitted, or imported. The **New Template** card at the top-left lets you import one from a public GitHub or GitLab repo.
 
-[**My Templates**](https://agents.pinata.cloud/templates) - Templates you've created or submitted. Create new templates by importing from a public GitHub or GitLab repo.
+Click any template card to open its details — description, skills it bundles, secrets it'll ask you for, and any scheduled tasks it sets up.
 
-Click any template to see what it does, what skills it includes, what secrets you'll need to provide, and whether it includes pre-configured scheduled tasks.
+## Deploying
 
-## Deploy It
-
-Once you've found a template you like:
+Once you've found one you like:
 
 1. Click **Deploy This Agent**
-2. Give your agent a name
-3. Add any secrets the template requires (usually just your LLM API key)
-4. Click **Deploy**
+2. Name your agent
+3. Provide whatever secrets the template asks for (usually just your LLM key)
+4. **Deploy**
 
-Your agent will spin up in about 30 seconds. You'll land on its chat page, ready to go.
+Provisioning takes about 30 seconds. You'll land on the agent's Chat tab, ready to talk to it.
 
-### What About Secrets?
+### A note on secrets
 
-Most templates need at least an LLM provider key (like `ANTHROPIC_API_KEY`). Some need additional keys - a Telegram template needs your bot token, a trading template might need exchange API keys.
+Every template needs at least an LLM provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.). Many need more — a Telegram template needs a bot token, a trading template might need exchange credentials.
 
-The template page shows exactly what's required. If you haven't added those secrets yet, you'll be prompted during setup. Or add them ahead of time in your [secrets vault](/agents/secrets).
+The template card spells out exactly what it needs. You can add the secrets ahead of time in the [Secrets Vault](/agents/secrets), or wait — the deploy flow prompts you for anything missing.
 
 ## Using the CLI
 
@@ -53,10 +52,16 @@ pinata agents create --template <template-id>   # Deploy one
 
 Built something useful? Package it as a template and share it with others - or just use it to quickly spin up copies of your own agents.
 
-<Card title="Creating Templates" icon="hammer" href="/agents/templates/creating">
-  Learn how to package your agent as a reusable template.
-</Card>
+<CardGroup cols={2}>
+  <Card title="Creating Templates" icon="hammer" href="/agents/templates/creating">
+    Walk through packaging your agent as a reusable template
+  </Card>
+
+  <Card title="Manifest reference" icon="file-code" href="/agents/manifest">
+    Full reference for every field in `manifest.json`
+  </Card>
+</CardGroup>
 
 <Card title="Reference Template" icon="github" horizontal href="https://github.com/PinataCloud/agent-template">
-  Clone this starter repo - it includes working examples of port forwarding, tasks, lifecycle scripts, and secrets.
+  Clone this starter repo - it includes working examples of routes, tasks, lifecycle scripts, and secrets.
 </Card>

--- a/agents/troubleshooting.mdx
+++ b/agents/troubleshooting.mdx
@@ -12,7 +12,7 @@ Most problems with an agent fall into a small number of buckets, and the answer 
 4. **Files** — if something used to work and broke after a recent change, restore an earlier snapshot from the [Files](/agents/snapshots) tab.
 5. **Validate config** — `POST /v0/templates/validate` checks `manifest.json`; `POST /v0/agents/{agentId}/config/validate` checks the runtime `openclaw.json`. These are two different files, see [Concepts](/agents/concepts#manifest-json-vs-openclaw-json) for the difference.
 
-If you're staring at an HTTP error code, the [Error reference](/agents/errors) goes status-by-status with verbatim error strings.
+If you're staring at an HTTP error code, the [Error reference](/agents/errors) goes status-by-status with the common responses.
 
 The rest of this page is symptom-first. Find what's happening, jump there.
 

--- a/agents/troubleshooting.mdx
+++ b/agents/troubleshooting.mdx
@@ -1,0 +1,230 @@
+---
+title: "Troubleshooting"
+description: "What to check when your agent isn't behaving"
+icon: "wrench"
+---
+
+Most problems with an agent fall into a small number of buckets, and the answer is almost always in one of five places. Before you scroll through symptoms, walk these in order — you'll often find it on step one.
+
+1. **Logs** — open the [Logs](/agents/logs) tab, uncheck everything except WARN and ERROR, and scroll up to the most recent red line. That's usually the answer.
+2. **Danger tab** — the [Danger](/agents/devtools) tab is the inventory page. Check status, last sync, the lifecycle-script state, and whether your secrets show as `Synced`.
+3. **Console** — the [Console](/agents/console) is a shell. `tail /tmp/user-build.log`, `env`, `ps aux` answer about 80% of "why doesn't my service work" questions.
+4. **Files** — if something used to work and broke after a recent change, restore an earlier snapshot from the [Files](/agents/snapshots) tab.
+5. **Validate config** — `POST /v0/templates/validate` checks `manifest.json`; `POST /v0/agents/{agentId}/config/validate` checks the runtime `openclaw.json`. These are two different files, see [Concepts](/agents/concepts#manifest-json-vs-openclaw-json) for the difference.
+
+If you're staring at an HTTP error code, the [Error reference](/agents/errors) goes status-by-status with verbatim error strings.
+
+The rest of this page is symptom-first. Find what's happening, jump there.
+
+## Agent won't start / stays in `starting`
+
+Symptom: status badge stuck on `starting`, no logs appearing, chat won't connect.
+
+**Check:**
+
+```bash
+# Are we still spinning up the container?
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID | jq '.processStatus'
+
+# Did the build script blow up?
+# Console → tail -n 200 /tmp/user-build.log
+```
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| `build` script failed | Fix the script, then **Retry Scripts** on the Danger tab (or `POST /v0/agents/{agentId}/scripts/retry`) |
+| Missing required secret | The Danger page flags missing secrets. Attach in the [Secrets Vault](/agents/secrets), then restart the gateway |
+| Container OOM | A heavy `npm install` or model load can hit the memory ceiling. Slim dependencies or break up the script |
+| OpenClaw version pinned to a broken release | Danger → **Change** to update to latest |
+
+## Gateway won't connect / chat is offline
+
+Symptom: chat shows "disconnected" or fails to reconnect.
+
+**Check:** the agent is `running` on the Danger tab, then look at Logs filtered to `gateway/ws`.
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| Gateway crashed | Danger → **Restart Gateway** |
+| Gateway token rotated and your client cached the old one | Copy the latest token from Danger, update your client |
+| Network/route returning 502 | Hard-refresh the page; if it persists, restart the gateway |
+| Browser blocked third-party cookies for `agents.pinata.cloud` | Pass the token via header or query string instead of relying on the cookie |
+
+## Build script failed
+
+Symptom: Danger → **Lifecycle Scripts** shows `build` failed; `start` never ran.
+
+**Read the log:**
+
+```bash
+# Console
+tail -n 200 /tmp/user-build.log
+```
+
+**Common causes:**
+
+- Wrong working directory - `build` runs from `/home/node/clawd`, not the workspace
+- Missing tooling (`pnpm`, `yarn`) - install in the build script first, or use a tool that ships with the image (`npm`)
+- `package.json` not found - `cd` into the right project subfolder
+- 5-minute timeout - split the work or pre-install in a snapshot
+
+Fix the script, then `POST /v0/agents/{agentId}/scripts/retry` (or click **Retry Scripts**).
+
+## Start script crashes immediately
+
+Symptom: `start` finishes seconds after launching - service is unreachable.
+
+```bash
+tail -n 200 /tmp/user-start.log
+ss -tlnp
+```
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| Bound to `127.0.0.1` / `localhost` | Bind to `0.0.0.0` so the gateway can reach it |
+| Port mismatch with `routes` entry | Make sure `manifest.json` `routes[i].port` matches what the server actually listens on |
+| Missing env var | `start` runs after `build` with the agent's full env - confirm with `env | grep MY_VAR` |
+| Process exits because it expected an interactive TTY | Add `--no-color`/`--no-progress` flags, or daemonize properly |
+
+<a id="routes"></a>
+## Routes not working / 404 / 502
+
+Symptom: the URL for your path route or custom domain doesn't load.
+
+**Walk through:**
+
+```bash
+# Is your service even listening?
+ss -tlnp
+
+# Hit it from inside the container
+curl -i http://localhost:5173/
+
+# Does the route show up in the API?
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/port-forwarding
+```
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| Service bound to `localhost` | Bind to `0.0.0.0` |
+| Wrong port | Match the listener's port in the route definition |
+| Path prefix mismatch | The prefix is stripped before reaching your service - `/app/foo` becomes `/foo`. Set your framework `base` accordingly (e.g. Vite `base: "/app"`) |
+| Allowed-hosts not configured | Vite/Next dev servers reject unknown hosts - add `__AGENT_HOST__` to the allow-list |
+| Custom domain stuck `pending_ownership` | TXT record not visible yet. Wait for DNS propagation or `dig TXT _pinata-verify.<your-domain>` |
+| Custom domain stuck `pending` | Cloudflare is still provisioning - usually clears in a few minutes |
+
+See [Routes & Domains](/agents/routes) for the full domain status table.
+
+## Secret update didn't apply
+
+Symptom: you updated a secret in the Vault but the agent still uses the old value.
+
+**Check:** Danger → **Secrets** → the per-secret **Synced** indicator. Out of sync means the running gateway hasn't been restarted since the update.
+
+**Fix:** Danger → **Restart Gateway**, or `POST /v0/agents/{agentId}/restart`.
+
+Secrets are injected at process start - they are not hot-reloaded.
+
+## Skill missing / not loading
+
+Symptom: agent doesn't seem to know about a skill you attached.
+
+**Check:**
+
+```bash
+# Is it actually attached?
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID | jq '.skills'
+
+# Are the files in the workspace?
+# Console: ls workspace/skills/
+```
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| Skill attached but agent not restarted | Restart the gateway |
+| Required env var declared in `.env.example` is missing | The Skills tab flags missing vars when you open the skill. Add the value to the Secrets Vault and attach it |
+| Skill version is out of date | Skills tab → click the skill → **Update** |
+| Skill installed from CID, not slug, and a newer version exists | Switch to the slug to track latest, or pin to a newer CID |
+
+## Custom domain stuck pending
+
+See [Routes → Custom domains](/agents/routes#custom-domains) - statuses are `pending_ownership` (TXT record), `pending` (Cloudflare provisioning), then `active`.
+
+```bash
+# Confirm DNS
+dig TXT _pinata-verify.app.example.com +short
+
+# Re-trigger verification
+curl -X POST \
+  -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/domains/$DOMAIN_ID/verify
+```
+
+## Device pairing rejects / stuck pending
+
+Symptom: a paired client (CLI, mobile) can't connect, or stays pending forever.
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/$AGENT_ID/devices
+```
+
+**Common causes:**
+
+- The device never sent an approval request - re-pair from the client
+- You're on a different workspace than the one you approved from - check **Account → Workspaces**
+- The agent is `not_running` - pairing requires the gateway to be up
+
+**Fix:** approve the request from the Danger page or `POST /v0/agents/{agentId}/devices/approve-all`.
+
+## Git push rejected
+
+Symptom: `git push` to your agent's workspace fails.
+
+**Common causes:**
+
+| Cause | Fix |
+| --- | --- |
+| Authentication failed | Copy a fresh URL with **Copy with Token** from the Files tab |
+| Local branch diverged | `git pull --rebase` first - the server commits the agent's pending changes before applying your push |
+| Pre-receive validation failed | Look at the rejected output - often a manifest validation error. Validate locally before pushing |
+
+## Tasks aren't firing
+
+Symptom: a scheduled task isn't running.
+
+**Check:**
+
+- Is the task enabled? `GET /v0/agents/{agentId}/tasks` with `includeDisabled=true`
+- Is the agent running? Tasks fire only while the gateway is up; missed runs during downtime are skipped
+- Check `cron/runner` lines in Logs around the expected time
+- Trigger manually: `POST /v0/agents/{agentId}/tasks/{jobId}/run` - if that works, the schedule is wrong
+
+## Costs / model usage looks off
+
+Switch the agent's model dropdown in chat to see what model is actually being used, or run `/status`. Tasks can specify their own `model` - re-check `payload.model` if a scheduled run looks unexpected.
+
+## Still stuck?
+
+Open a ticket from **Support → Chat with us** in the sidebar, or email `team@pinata.cloud`. Useful info to include:
+
+- Agent ID (Danger → Agent → Agent ID)
+- OpenClaw version
+- A recent `EXPORT VISIBLE` from the Logs tab (filter to `ERROR` first)
+- The relevant section of `manifest.json` if config-related
+- What you expected vs. what happened
+
+For HTTP errors, the [Error reference](/agents/errors) often has the answer faster than a support round-trip.

--- a/docs.json
+++ b/docs.json
@@ -66,6 +66,7 @@
                 "icon": "lobster",
                 "pages": [
                   "agents/overview",
+                  "agents/concepts",
                   "agents/chat",
                   "agents/secrets",
                   "agents/models",
@@ -84,11 +85,27 @@
                     ]
                   },
                   {
+                    "group": "Build",
+                    "icon": "code",
+                    "pages": [
+                      "agents/manifest",
+                      "agents/api"
+                    ]
+                  },
+                  {
                     "group": "Templates",
                     "icon": "clone",
                     "pages": [
                       "agents/templates/overview",
                       "agents/templates/creating"
+                    ]
+                  },
+                  {
+                    "group": "Troubleshooting",
+                    "icon": "wrench",
+                    "pages": [
+                      "agents/troubleshooting",
+                      "agents/errors"
                     ]
                   }
                 ]


### PR DESCRIPTION
## Summary

- Updates every existing agent doc page to match the current dashboard (new sidebar, new tabs, manifest.v1 schema, ClawHub, custom domains, Codex/Claude subscription auth, slash commands)
- Adds a developer-focused reference layer for users who need to debug without overwhelming the getting-started path:
  - `agents/concepts` — glossary, file layout, manifest.json vs openclaw.json
  - `agents/manifest` — full manifest.v1 field reference
  - `agents/api` — auth model and endpoint quick reference
  - `agents/troubleshooting` — symptom-first debugging guide
  - `agents/errors` — HTTP status codes and verbatim error string lookup
- Re-grounded UI references against the actual screenshots and rewrote for human readability, while keeping the dense reference tables intact for agent/LLM consumers
- No URL changes — every existing slug is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)