### PR TITLE
Document Hermes engine in agent docs

### DIFF
--- a/agents/api.mdx
+++ b/agents/api.mdx
@@ -92,11 +92,23 @@ curl -X POST \
     "name": "My Agent",
     "description": "Personal assistant",
     "emoji": "🤖",
+    "engine": "openclaw",
     "skillCids": ["@pinata/api"],
     "secretIds": ["secret-id-1"]
   }' \
   https://agents.pinata.cloud/v0/agents
 ```
+
+`engine` is optional and defaults to `openclaw`. Pass `hermes` to provision the opinionated engine instead — see [Concepts → Engine](/agents/concepts#engine). For Hermes agents you can also pass a `channels` object on create (Telegram / Slack / Discord token + DM policy) and the channel will come up with the agent, avoiding a post-creation restart.
+
+To list engines enabled for the current deployment:
+
+```bash
+curl -H "Authorization: Bearer $PINATA_JWT" \
+  https://agents.pinata.cloud/v0/agents/engines
+```
+
+Returns `{ "engines": [ { "id": "openclaw", "label": "OpenClaw" }, { "id": "hermes", "label": "Hermes" } ] }`.
 
 Returns `201` with the created agent. Returns `403` if you're at the agent limit.
 

--- a/agents/channels.mdx
+++ b/agents/channels.mdx
@@ -73,7 +73,7 @@ Same shape as Telegram — make a bot in Discord's developer portal, copy the to
 - **Remove** — same dialog, **Remove** action. This deletes the channel config and restarts the agent's gateway.
 
 <Note>
-  Channel changes take effect after the gateway restarts. Configure and remove handle that automatically.
+  Channel changes take effect after the gateway restarts. Configure and remove handle that automatically. If you're creating a [Hermes](/agents/concepts#engine) agent via the API, pass a `channels` object on `POST /v0/agents` to wire them up at creation and avoid the post-create restart entirely — see [API → Create an agent](/agents/api#create-an-agent).
 </Note>
 
 <Warning>

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -29,7 +29,14 @@ A single isolated container with a persistent workspace, gateway, and `{agentId}
 
 ### Engine
 
-The runtime that powers the agent. `openclaw` is the default; `hermes` is also enumerated. Set via `engine` in [`manifest.json`](/agents/manifest).
+The runtime that powers the agent. Two engines are supported:
+
+| Engine | Tagline | When to pick it |
+| --- | --- | --- |
+| `openclaw` (default) | Configurable agent for custom workflows and power users | You want full control over manifest fields, scripts, routes, and skills |
+| `hermes` | Opinionated agent with a smoother out-of-the-box experience | You want fewer knobs and channels wired up from the start |
+
+Pick the engine when creating the agent — either in the **Agent Engine** card on the Create Agent wizard, or by passing `engine` in `POST /v0/agents`, or by setting `engine` in [`manifest.json`](/agents/manifest) for a template. Available engines per deployment are listed at `GET /v0/agents/engines`.
 
 ### Gateway
 

--- a/agents/models.mdx
+++ b/agents/models.mdx
@@ -49,7 +49,7 @@ openrouter/tencent/hy3-preview
 openai/gpt-5.4
 ```
 
-The provider prefix tells OpenClaw which connected provider to use. If you give it a model that isn't enabled on this agent, the request falls back to the default.
+The provider prefix tells the agent engine (OpenClaw or Hermes) which connected provider to use. If you give it a model that isn't enabled on this agent, the request falls back to the default.
 
 ## What's available today
 

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -6,7 +6,7 @@ icon: "lobster"
 
 Pinata Agents gives you a hosted AI agent in its own sandboxed container. The agent has a workspace it can read and write to, a terminal it can run commands in, and connectors for the outside world — chat apps, web servers, scheduled jobs. You talk to it through the dashboard, the CLI, or whichever messaging platform you connect it to.
 
-Under the hood, each agent runs the [OpenClaw](https://openclaw.org) engine. You don't have to know OpenClaw to use one, but if you go deep, that's the project to read.
+Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, or `hermes` for an opinionated, smoother out-of-the-box experience. You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
 
 <Note>
   Agents require a paid Pinata plan. [Upgrade here](https://app.pinata.cloud/billing).
@@ -35,7 +35,7 @@ Head to [My Agents](https://agents.pinata.cloud/agents) and click **Create Agent
 You have two paths:
 
 - **Start from a template** — fastest. Templates come pre-wired with skills, settings, and a personality. Pick one from the [Marketplace](https://agents.pinata.cloud/marketplace) (others' templates) or [My Templates](https://agents.pinata.cloud/templates) (your own). Add the secrets it needs, deploy.
-- **Build from scratch** — full control. The wizard walks you through naming the agent, picking a personality preset (Atlas, Nova, Sage, or custom), choosing skills, and connecting your LLM provider.
+- **Build from scratch** — full control. The wizard walks you through naming the agent, choosing an **Agent Engine** (OpenClaw or Hermes), picking a personality preset (Atlas, Nova, Sage, or custom), choosing skills, and connecting your LLM provider.
 
 Either way, the agent takes about 30 seconds to provision. When it's ready you land on its Chat tab.
 

--- a/agents/troubleshooting.mdx
+++ b/agents/troubleshooting.mdx
@@ -38,7 +38,7 @@ curl -H "Authorization: Bearer $PINATA_JWT" \
 | `build` script failed | Fix the script, then **Retry Scripts** on the Danger tab (or `POST /v0/agents/{agentId}/scripts/retry`) |
 | Missing required secret | The Danger page flags missing secrets. Attach in the [Secrets Vault](/agents/secrets), then restart the gateway |
 | Container OOM | A heavy `npm install` or model load can hit the memory ceiling. Slim dependencies or break up the script |
-| OpenClaw version pinned to a broken release | Danger → **Change** to update to latest |
+| Engine version pinned to a broken release | Danger → **Change** to update to latest (works for OpenClaw and Hermes) |
 
 ## Gateway won't connect / chat is offline
 


### PR DESCRIPTION
## Summary
- Agents API v0.11.4 adds the **Hermes** engine alongside OpenClaw; reflect the choice end-to-end in the prose docs.
- Overview intro and Create Agent wizard step now mention the **Agent Engine** selector (OpenClaw / Hermes); concepts gains a comparison table and a pointer to `GET /v0/agents/engines`.
- API doc shows `engine` on `POST /v0/agents`, documents the engines listing endpoint, and calls out that Hermes accepts a `channels` object on create so channels can be wired up without a post-create restart.
- Generalised stray OpenClaw-only phrasing in `models.mdx`, `channels.mdx`, and `troubleshooting.mdx`.