### PR TITLE
Document the Hermes agent engine across agent + CLI docs

### DIFF
--- a/agents/api.mdx
+++ b/agents/api.mdx
@@ -5,7 +5,7 @@ description: "Authenticate, manage agents, and talk to gateways over HTTP"
 icon: "plug"
 ---
 
-The Agents API is the same API the dashboard uses. Everything in the UI is exposed at `agents.pinata.cloud` - including agent management, secrets, skills, channels, snapshots, custom domains, devices, and OpenClaw config.
+The Agents API is the same API the dashboard uses. Everything in the UI is exposed at `agents.pinata.cloud` - including agent management, secrets, skills, channels, snapshots, custom domains, devices, and engine runtime config.
 
 Full OpenAPI reference: [agents.pinata.cloud/openapi](https://agents.pinata.cloud/openapi) (also linked from the Support → OpenAPI Docs item in the sidebar).
 
@@ -67,7 +67,7 @@ Inside an agent, the `@pinata/platform` skill can exchange the gateway token for
 ```bash
 # From inside the agent container:
 curl -X POST \
-  -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" \
+  -H "Authorization: Bearer $GATEWAY_TOKEN" \
   https://{agentId}.agents.pinata.cloud/v0/platform/token
 ```
 
@@ -99,7 +99,16 @@ curl -X POST \
   https://agents.pinata.cloud/v0/agents
 ```
 
-`engine` is optional and defaults to `openclaw`. Pass `hermes` to provision the opinionated engine instead — see [Concepts → Engine](/agents/concepts#engine). For Hermes agents you can also pass a `channels` object on create (Telegram / Slack / Discord token + DM policy) and the channel will come up with the agent, avoiding a post-creation restart.
+`engine` is optional and defaults to `openclaw`. Pass `hermes` for the opinionated engine — see [Concepts → Engine](/agents/concepts#engine). For chat-oriented engines, the dashboard exposes channel setup during create, and engines that support create-time channel bootstrap can accept a `channels` object on this request so Telegram, Slack, or Discord come up with the agent without a post-create gateway restart. Each channel object accepts:
+
+| Field | Type | Required | Notes |
+| --- | --- | :---: | --- |
+| `botToken` | string | yes (all channels) | Bot token from the platform. Slack uses the `xoxb-` bot token. |
+| `appToken` | string | yes (Slack only) | Slack `xapp-` app-level token for Socket Mode. |
+| `dmPolicy` | string | optional | `open` (anyone can DM) or `pairing` (must be approved). Defaults to `open`. |
+| `allowFrom` | array of strings | optional | Allow-list of platform user IDs that can DM the bot. |
+
+These are the same fields accepted by the per-channel `POST /v0/agents/{agentId}/channels/{channel}` endpoint and by `channels` in [`manifest.json`](/agents/manifest#channels).
 
 To list engines enabled for the current deployment:
 
@@ -108,7 +117,7 @@ curl -H "Authorization: Bearer $PINATA_JWT" \
   https://agents.pinata.cloud/v0/agents/engines
 ```
 
-Returns `{ "engines": [ { "id": "openclaw", "label": "OpenClaw" }, { "id": "hermes", "label": "Hermes" } ] }`.
+Returns `{ "engines": [ { "id": "openclaw", "label": "OpenClaw" }, { "id": "hermes", "label": "Hermes" } ] }`, depending on which engines are enabled for the deployment.
 
 Returns `201` with the created agent. Returns `403` if you're at the agent limit.
 
@@ -263,7 +272,7 @@ Compact index of every endpoint, grouped by purpose. `JWT` = Pinata JWT, `GW` = 
 | `DELETE` | `/v0/agents/{agentId}` | JWT | Delete the agent |
 | `POST` | `/v0/agents/{agentId}/restart` | JWT / GW | Restart the gateway |
 | `GET` | `/v0/agents/{agentId}/logs` | JWT / GW | Last 100 log lines |
-| `GET` | `/v0/agents/engines` | JWT | List available engines (`openclaw`, `hermes`) |
+| `GET` | `/v0/agents/engines` | JWT | List available engines (`openclaw`, `hermes`, etc.) |
 | `GET` | `/v0/agents/{agentId}/available-agent-versions` | JWT / GW | Versions you can upgrade to |
 | `POST` | `/v0/agents/{agentId}/scripts/retry` | JWT / GW | Re-run `build` then `start` |
 | `GET` | `/v0/agents/{agentId}/update` | JWT / GW | Check for OpenClaw updates |
@@ -366,16 +375,16 @@ Compact index of every endpoint, grouped by purpose. `JWT` = Pinata JWT, `GW` = 
 | `POST` | `/v0/agents/{agentId}/devices/{requestId}/approve` | JWT / GW | Approve one |
 | `POST` | `/v0/agents/{agentId}/devices/approve-all` | JWT / GW | Approve every pending |
 
-### Config (OpenClaw runtime)
+### Config (engine runtime)
 
 | Method | Path | Auth | Description |
 | --- | --- | :---: | --- |
-| `GET` | `/v0/agents/{agentId}/config` | JWT / GW | Read `openclaw.json` |
-| `PUT` | `/v0/agents/{agentId}/config` | JWT / GW | Write `openclaw.json` (validated server-side) |
-| `POST` | `/v0/agents/{agentId}/config/validate` | JWT / GW | Validate `openclaw.json` without applying |
+| `GET` | `/v0/agents/{agentId}/config` | JWT / GW | Read the engine runtime config shown in the Danger tab |
+| `PUT` | `/v0/agents/{agentId}/config` | JWT / GW | Write runtime config (validated server-side) |
+| `POST` | `/v0/agents/{agentId}/config/validate` | JWT / GW | Validate runtime config without applying |
 
 <Note>
-  Note `config/validate` validates `openclaw.json` (runtime config), **not** `manifest.json`. To validate a manifest, use `POST /v0/templates/validate` or run `pinata agents templates validate`.
+  Note `config/validate` validates runtime config, **not** `manifest.json`. OpenClaw agents use `/home/node/.openclaw/openclaw.json`; Hermes agents use `/home/hermes/data/config.yaml`. To validate a manifest, use `POST /v0/templates/validate` or run `pinata agents templates validate`.
 </Note>
 
 ### Templates

--- a/agents/channels.mdx
+++ b/agents/channels.mdx
@@ -73,7 +73,7 @@ Same shape as Telegram — make a bot in Discord's developer portal, copy the to
 - **Remove** — same dialog, **Remove** action. This deletes the channel config and restarts the agent's gateway.
 
 <Note>
-  Channel changes take effect after the gateway restarts. Configure and remove handle that automatically. If you're creating a [Hermes](/agents/concepts#engine) agent via the API, pass a `channels` object on `POST /v0/agents` to wire them up at creation and avoid the post-create restart entirely — see [API → Create an agent](/agents/api#create-an-agent).
+  Channels are available for chat-oriented engines such as OpenClaw and Hermes. Channel changes take effect after the gateway restarts; Configure and Remove handle that automatically. The create wizard can collect channel setup before deployment. If you're creating an agent via the API or CLI, pass a `channels` object on `POST /v0/agents` for engines that support create-time channel bootstrap — see [API → Create an agent](/agents/api#create-an-agent).
 </Note>
 
 <Warning>

--- a/agents/chat.mdx
+++ b/agents/chat.mdx
@@ -4,7 +4,7 @@ description: "Talk to your agent through the web interface"
 icon: "message"
 ---
 
-The Chat tab is your main conversation with the agent. Messages stream in real time. You see your prompts, the agent's responses, any tools it called along the way, and — if you enable it — its thinking.
+The Chat tab is your main conversation with the agent. You see your prompts, the agent's responses, any tools it called along the way, and — if you enable it — its thinking.
 
 Open your agent → **Chat**.
 
@@ -31,7 +31,7 @@ Type `/` at the start of a message to run a command instead of a regular prompt:
 | `/status` | Prints the current model, session info, and key flags |
 | `/help` | Shows the commands your agent supports |
 
-The list depends on your agent's OpenClaw version and any skills you've attached, so `/help` is the best way to see what's actually available.
+The list depends on your agent engine and any skills you've attached, so `/help` is the best way to see what's actually available.
 
 ## Reading agent responses
 
@@ -43,6 +43,8 @@ Each turn the agent sends back has a few elements you'll see in the chat:
 - **Model badge** — after the response, a small badge shows which model produced it. Useful when you've been switching models mid-conversation.
 
 When you want to debug a bad answer, expand the thinking block and the tool calls before anything else. That's almost always where the answer is.
+
+Response delivery is engine-specific. OpenClaw agents usually stream assistant text token-by-token; Hermes agents can deliver a complete assistant message in one event. The transcript renders the same either way, but the reply may appear to type in for OpenClaw and appear all at once for Hermes.
 
 ## Switching models mid-conversation
 
@@ -60,4 +62,4 @@ Click **Hide navbar** in the top-right corner to collapse the left sidebar — t
 - If the chat looks disconnected and stays that way, the gateway probably needs a kick. Open **Danger** → **Restart Gateway**.
 - If you change a secret, attach a new skill, or add a channel, restart the gateway so the agent picks up the change.
 
-For deeper debugging, the [Logs](/agents/logs) tab streams everything OpenClaw is doing under the hood. See [Troubleshooting](/agents/troubleshooting) for common failure modes.
+For deeper debugging, the [Logs](/agents/logs) tab streams what the agent engine is doing under the hood. See [Troubleshooting](/agents/troubleshooting) for common failure modes.

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -19,7 +19,7 @@ Workspace (your team)  ──►  Agent (container)  ──►  Channels / Route
 Pinata IPFS + R2 (storage)
 ```
 
-A **workspace** is a Pinata team. Inside it you create one or more **agents** — each is an isolated container running the [OpenClaw](https://openclaw.org) engine, with its own files, gateway, and per-agent subdomain.
+A **workspace** is a Pinata team. Inside it you create one or more **agents** — each is an isolated container running an agent engine, with its own files, gateway, and per-agent subdomain.
 
 ## Glossary
 
@@ -29,12 +29,12 @@ A single isolated container with a persistent workspace, gateway, and `{agentId}
 
 ### Engine
 
-The runtime that powers the agent. Two engines are supported:
+The runtime that powers the agent. Engines are enabled per deployment:
 
 | Engine | Tagline | When to pick it |
 | --- | --- | --- |
 | `openclaw` (default) | Configurable agent for custom workflows and power users | You want full control over manifest fields, scripts, routes, and skills |
-| `hermes` | Opinionated agent with a smoother out-of-the-box experience | You want fewer knobs and channels wired up from the start |
+| `hermes` | Opinionated agent with a smoother out-of-the-box experience | You want fewer knobs and first-run channel setup to feel more direct |
 
 Pick the engine when creating the agent — either in the **Agent Engine** card on the Create Agent wizard, or by passing `engine` in `POST /v0/agents`, or by setting `engine` in [`manifest.json`](/agents/manifest) for a template. Available engines per deployment are listed at `GET /v0/agents/engines`.
 
@@ -64,7 +64,7 @@ Per-agent credential used to authenticate against the agent's own subdomain (`{a
 Two meanings - context disambiguates:
 
 1. **Team workspace** - your Pinata account or shared team. Switch under **Account → Workspaces**.
-2. **Agent workspace** - the per-agent file tree at `/home/node/clawd/workspace/` inside the container. Includes [`manifest.json`](/agents/manifest), `SOUL.md`, attached skills under `skills/`, file uploads under `uploads/`, and anything else your agent has written.
+2. **Agent workspace** - the per-agent file tree inside the container. OpenClaw agents use `/home/node/clawd/workspace/`; Hermes agents use `/home/hermes/data/workspace/`. The workspace includes [`manifest.json`](/agents/manifest), `SOUL.md`, attached skills under `skills/`, file uploads under `uploads/`, and anything else your agent has written.
 
 ### Workspace anatomy
 
@@ -85,16 +85,19 @@ The default file layout inside `workspace/`:
 
 You can commit and push anything else (`projects/`, `scripts/`, etc.) - the agent treats the whole tree as fair game.
 
-### `manifest.json` vs `openclaw.json`
+<a id="manifest-json-vs-openclaw-json"></a>
 
-These are two different files. Both are JSON; they live in different places and have different schemas.
+### `manifest.json` vs runtime config
+
+These are different files. They live in different places and have different schemas.
 
 | File | Path | Schema | Edited by |
 | --- | --- | --- | --- |
 | `manifest.json` | `<workspace>/manifest.json` | [`manifest.v1.json`](/agents/manifest) | You (committed to git, validated via `POST /v0/templates/validate`) |
-| `openclaw.json` | `/home/node/.openclaw/openclaw.json` | OpenClaw runtime schema | OpenClaw at runtime (validated via `POST /v0/agents/{agentId}/config/validate`) |
+| OpenClaw runtime config | `/home/node/.openclaw/openclaw.json` | OpenClaw runtime schema | OpenClaw at runtime (validated via `POST /v0/agents/{agentId}/config/validate`) |
+| Hermes runtime config | `/home/hermes/data/config.yaml` | Hermes runtime schema | Hermes at runtime (edited from the Danger tab's Config row) |
 
-Day-to-day, edit `manifest.json`. `openclaw.json` is the engine's runtime mirror and is generally only touched via the **OpenClaw Settings UI** on the Danger tab.
+Day-to-day, edit `manifest.json`. Runtime config is the engine's own view of that configuration and is usually only touched from the [Danger](/agents/devtools) tab when you're debugging the engine itself.
 
 ### Skill
 
@@ -158,11 +161,13 @@ Paths agents and developers reach for most often inside the container:
 
 | Path | What's there |
 | --- | --- |
-| `/home/node/clawd/` | Runner root - where `build`/`start` execute |
-| `/home/node/clawd/workspace/` | Agent workspace (see anatomy above) |
-| `/home/node/clawd/workspace/skills/<name>/` | Attached skill files |
-| `/home/node/clawd/workspace/uploads/` | Uploaded files |
+| `/home/node/clawd/` | OpenClaw runner root - where `build`/`start` execute |
+| `/home/node/clawd/workspace/` | OpenClaw workspace |
+| `/home/hermes/data/workspace/` | Hermes workspace |
+| `<workspace>/skills/<name>/` | Attached skill files |
+| `<workspace>/uploads/` | Uploaded files |
 | `/home/node/.openclaw/openclaw.json` | OpenClaw runtime config |
+| `/home/hermes/data/config.yaml` | Hermes runtime config |
 | `/tmp/openclaw/openclaw-YYYY-MM-DD.log` | Daily OpenClaw log file |
 | `/tmp/user-build.log` | `build` script output |
 | `/tmp/user-start.log` | `start` script output |

--- a/agents/console.mdx
+++ b/agents/console.mdx
@@ -17,6 +17,8 @@ Working directory: /home/node/clawd/workspace
 ~/clawd/workspace $
 ```
 
+That example is an OpenClaw agent. Hermes agents use `/home/hermes/data/workspace`. The current path is also shown on the agent's [Danger](/agents/devtools) tab.
+
 Anything you can do with a shell, you can do here:
 
 - Run `bash`, `python`, `node`, `git`, `curl`, `jq`
@@ -25,7 +27,7 @@ Anything you can do with a shell, you can do here:
 - Confirm a service is listening: `ss -tlnp`
 - Edit a file with `vi` or `nano`
 
-The session starts in `/home/node/clawd/workspace` — the same workspace shown on the Files tab. Skills live under `skills/`, uploaded files under `uploads/`.
+The session starts in the engine's workspace directory — the same workspace shown on the Files and Danger tabs. Skills live under `skills/`, uploaded files under `uploads/`.
 
 <Tip>
   The button in the top-right of the panel switches to fullscreen mode, which is much more pleasant for anything beyond a one-liner.
@@ -49,14 +51,17 @@ tail -n 200 /tmp/user-build.log
 # What did the start script say?
 tail -n 200 /tmp/user-start.log
 
-# Latest OpenClaw log
+# Latest OpenClaw log (OpenClaw agents)
 ls -la /tmp/openclaw/
 
 # OpenClaw runtime config
 cat /home/node/.openclaw/openclaw.json
 
+# Hermes runtime config
+cat /home/hermes/data/config.yaml
+
 # Manifest the agent is using
-cat workspace/manifest.json
+cat manifest.json
 
 # Is anything listening on common dev ports?
 ss -tlnp
@@ -68,11 +73,13 @@ For workflows by symptom, see [Troubleshooting](/agents/troubleshooting).
 
 If you're scripting against an agent, hit the API:
 
+Set `cwd` to the workspace path for that engine. For OpenClaw that's `/home/node/clawd/workspace`; for Hermes that's `/home/hermes/data/workspace`.
+
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $PINATA_JWT" \
   -H "Content-Type: application/json" \
-  -d '{"command":"ls -la workspace","cwd":"/home/node/clawd"}' \
+  -d '{"command":"ls -la","cwd":"/home/node/clawd/workspace"}' \
   https://agents.pinata.cloud/v0/agents/$AGENT_ID/console/exec
 ```
 

--- a/agents/devtools.mdx
+++ b/agents/devtools.mdx
@@ -4,7 +4,7 @@ description: "Full agent inventory, plus restart and delete"
 icon: "triangle-exclamation"
 ---
 
-The Danger tab does two things. First, it's the single place where you can see *everything* about an agent — every secret attached, every skill installed, every channel configured, every snapshot CID. It's also where you'll find restart, settings edit, and delete.
+The Danger tab does two things. First, it's the single place where you can see *everything* about an agent — every secret attached, every skill installed, every channel configured, every snapshot CID. It's also where you'll find restart, runtime config edit, and delete.
 
 The name is mostly about the buttons at the bottom — Restart Gateway is disruptive, Delete is permanent. But it's also the page you'll open most often when you're answering "how is this agent actually configured?"
 
@@ -12,8 +12,8 @@ The name is mostly about the buttons at the bottom — Restart Gateway is disrup
 
 Two big sections.
 
-- **General** — agent details, workspace state, lifecycle scripts, channels, skills, devices, secrets. One row at a time.
-- **Actions** — three buttons: Restart Gateway, OpenClaw Settings UI, Delete This Agent.
+- **General** — agent details, workspace state, lifecycle scripts, channels where supported, skills, devices, secrets. One row at a time.
+- **Actions** — engine-specific controls such as Restart Gateway, OpenClaw Settings UI, and Delete This Agent.
 
 ## Agent details
 
@@ -24,20 +24,22 @@ The first block in **General** is the agent itself:
 | **Agent ID** | The unique slug used in URLs and API calls (e.g. `x0i33jye`) |
 | **Status** | `starting`, `running`, or `not_running` |
 | **Name** | What you named it |
-| **Engine** | The container engine — `openclaw` (default) or `hermes` |
-| **Version** | Engine version. **Change** lets you bump it. |
-| **Config** | Path to `openclaw.json` inside the container. **Edit** opens an editor. |
+| **Engine** | The container engine — `openclaw` (default), `hermes`, or another enabled engine |
+| **Version** | Engine version, when the engine exposes one. OpenClaw agents show **Change** for version updates. |
+| **Config** | Path to the engine runtime config. OpenClaw uses `/home/node/.openclaw/openclaw.json`; Hermes uses `/home/hermes/data/config.yaml`. **Edit** opens an editor. |
 | **Gateway Token** | The credential used to authenticate against the agent's own subdomain. See [API → Gateway token](/agents/api#gateway-token). |
 | **Created** | When the agent was created |
 | **Base URL** | `https://{agentId}.agents.pinata.cloud` |
 
 The **manifest.json schema** link at the top of this section jumps to the [full field reference](/agents/manifest).
 
+While a new agent is still `starting`, Chat and most settings tabs are disabled. The Danger tab stays available so you can check the current status, engine, config path, workspace path, and delete the agent if provisioning went wrong.
+
 ## Workspace
 
 | Field | What it shows |
 | --- | --- |
-| **Path** | The workspace directory inside the container (default `/home/node/clawd/workspace`) |
+| **Path** | The workspace directory inside the container. OpenClaw uses `/home/node/clawd/workspace`; Hermes uses `/home/hermes/data/workspace`. |
 | **Snapshot CID** | IPFS CID of the most recent synced snapshot |
 | **Last Sync** | How recently the workspace was captured |
 
@@ -47,7 +49,7 @@ For diffs and restore, use the [Files](/agents/snapshots) tab.
 
 Whether your `build` and `start` scripts are configured, and their current status. The states are self-explanatory: `Not configured`, `pending`, `running`, `success`, `failed`.
 
-If something failed, use the **OpenClaw Settings UI** action or `POST /v0/agents/{agentId}/scripts/retry` to re-run the lifecycle. Logs end up in `/tmp/user-build.log` and `/tmp/user-start.log` — see [Manifest → Scripts](/agents/manifest#scripts) for the details.
+If something failed, use `POST /v0/agents/{agentId}/scripts/retry` to re-run the lifecycle. OpenClaw agents also expose the **OpenClaw Settings UI** action for low-level runtime debugging. Logs end up in `/tmp/user-build.log` and `/tmp/user-start.log` — see [Manifest → Scripts](/agents/manifest#scripts) for the details.
 
 ## Scheduled Tasks
 
@@ -55,7 +57,7 @@ Just a status summary. Manage them on the [Tasks](/agents/tasks) tab.
 
 ## Channels
 
-A quick rollup — for each of Telegram, Slack, Discord, and WhatsApp, you'll see either `Enabled` or `Not configured`.
+A quick rollup for engines that support messaging channels. For each of Telegram, Slack, Discord, and WhatsApp, you'll see either `Enabled` or `Not configured`.
 
 ## Skills
 
@@ -102,15 +104,17 @@ curl -X POST \
 
 ### OpenClaw Settings UI
 
-Opens OpenClaw's internal settings panel. This is a low-level config editor for the engine itself — useful for advanced debugging.
+OpenClaw agents show an **Open Settings UI** action. It opens OpenClaw's internal settings panel, a low-level config editor for the engine itself — useful for advanced debugging.
 
 <Warning>
   Misconfiguration here can break the agent. For day-to-day config, edit `manifest.json` instead. See the [manifest reference](/agents/manifest).
 </Warning>
 
+Hermes agents do not show this action. Use the **Config** row's **Edit** button for Hermes runtime config.
+
 ### Edit config
 
-The **Edit** button next to the **Config** row opens `openclaw.json` directly. Changes are validated server-side before they're written.
+The **Edit** button next to the **Config** row opens the engine runtime config directly. For OpenClaw this is `openclaw.json`; for Hermes it is `config.yaml`. Changes are validated server-side before they're written.
 
 You can also validate any config string without applying it:
 
@@ -122,11 +126,11 @@ curl -X POST \
   https://agents.pinata.cloud/v0/agents/$AGENT_ID/config/validate
 ```
 
-This validates `openclaw.json` (the runtime config), not `manifest.json`. For manifest validation, see [Manifest → Validation](/agents/manifest#validation).
+This validates the runtime config, not `manifest.json`. For manifest validation, see [Manifest → Validation](/agents/manifest#validation).
 
 ### Update OpenClaw
 
-The **Change** button next to the Version field checks for updates and applies them. Equivalent CLI calls:
+OpenClaw agents show a **Change** button next to the Version field. It checks for updates and applies them. Equivalent CLI calls:
 
 ```bash
 # Check

--- a/agents/errors.mdx
+++ b/agents/errors.mdx
@@ -98,9 +98,9 @@ Common variants:
 | --- | --- | --- |
 | `Gateway failed to start` after agent create | Provisioning succeeded but the gateway crashed | Wait 30s and retry, or check Logs |
 | `Sync failed` | Workspace snapshot upload to Pinata IPFS failed | Retry; if persistent, check Pinata status |
-| `CLI error` on `GET /v0/agents/{agentId}/devices` | Underlying OpenClaw CLI returned non-zero | Check Logs for OpenClaw errors; restart gateway |
+| `CLI error` on `GET /v0/agents/{agentId}/devices` | Underlying engine CLI returned non-zero | Check Logs for engine errors; restart gateway |
 | `Reset failed` | Git reset to the snapshot commit failed | The commit hash may be missing - try a different snapshot |
-| `Configuration failed` on channel configure | OpenClaw rejected the channel config | Validate token format (e.g. Slack `xoxb-` / `xapp-`) |
+| `Configuration failed` on channel configure | The engine rejected the channel config | Validate token format (e.g. Slack `xoxb-` / `xapp-`) |
 | `Execution failed` on console exec | Command shell terminated unexpectedly | Inspect the command; if hung, restart gateway |
 
 ### `503 Service Unavailable`
@@ -124,11 +124,11 @@ Re-grab the URL with **Copy with Token** on the Files tab. The gateway token may
 
 ### "Tasks return 500 from `GET /v0/agents/.../tasks`"
 
-This usually means the OpenClaw CLI inside the container failed. Restart the gateway; if it keeps failing, check the Logs filtered to `cron/runner`.
+This usually means the engine CLI inside the container failed. Restart the gateway; if it keeps failing, check the Logs filtered to `cron/runner`.
 
 ### "Channel configure returns 500"
 
-OpenClaw could not write the channel config or restart. Almost always a malformed token or a channel that's already enabled. Re-check the token, then **Reconfigure**.
+The engine could not write the channel config or restart. Almost always a malformed token or a channel that's already enabled. Re-check the token, then **Reconfigure**.
 
 ### "Domain stuck `pending_ownership`"
 
@@ -151,26 +151,26 @@ Errors documented in the API spec, grouped by where they appear. Use this as a s
 | `Snapshot not found` | `POST /v0/agents/{agentId}/snapshots/reset` (`404`) | Snapshot CID isn't in this agent's history |
 | `Invalid snapshot CID` | Snapshot reset (`400`) | The provided CID didn't parse |
 | `Unsupported channel` | `DELETE /v0/agents/{agentId}/channels/{channel}` (`400`) | Channel must be `telegram` / `slack` / `discord` / `whatsapp` |
-| `Configuration failed` | Channel configure (`500`) | OpenClaw rejected the token/config |
-| `Removal failed` | Channel delete (`500`) | OpenClaw failed to remove and restart |
+| `Configuration failed` | Channel configure (`500`) | Engine rejected the token/config |
+| `Removal failed` | Channel delete (`500`) | Engine failed to remove and restart |
 | `Invalid command` | Console exec (`400`) | `command` field empty or invalid `cwd` |
 | `Execution failed` | Console exec (`500`) | Shell exited unexpectedly |
-| `Invalid JSON` | Config validate / write (`400`) | The `config` field isn't valid JSON |
-| `Validation command failed` | `POST /v0/agents/{agentId}/config/validate` (`500`) | OpenClaw CLI returned non-zero |
-| `Failed to read config` | `GET /v0/agents/{agentId}/config` (`500`) | Couldn't read `openclaw.json` |
-| `Failed to write config` | `PUT /v0/agents/{agentId}/config` (`500`) | Couldn't write `openclaw.json` |
-| `Invalid version` | `POST /v0/agents/{agentId}/restart` (`400`) | Requested OpenClaw version doesn't exist |
+| `Invalid JSON` / invalid config | Config validate / write (`400`) | The `config` field isn't valid for this engine |
+| `Validation command failed` | `POST /v0/agents/{agentId}/config/validate` (`500`) | Engine validator returned non-zero |
+| `Failed to read config` | `GET /v0/agents/{agentId}/config` (`500`) | Couldn't read runtime config |
+| `Failed to write config` | `PUT /v0/agents/{agentId}/config` (`500`) | Couldn't write runtime config |
+| `Invalid version` | `POST /v0/agents/{agentId}/restart` (`400`) | Requested engine version doesn't exist |
 | `Restart failed` | Restart (`500`) | Gateway didn't come back up — check Logs |
 | `Script launch failed` | `POST /v0/agents/{agentId}/scripts/retry` (`500`) | Build or start couldn't be launched |
 | `File too large` | `POST /v0/agents/{agentId}/files/upload` (`413`) | Body over the upload limit — chunk or push via git |
-| `CLI error` | Several OpenClaw-backed endpoints (`500`) | Underlying `openclaw` CLI returned non-zero — check Logs |
+| `CLI error` | Several engine-backed endpoints (`500`) | Underlying engine CLI returned non-zero — check Logs |
 | `Token generation failed` | `POST /v0/agents/{agentId}/platform/token` (`500`) | Platform JWT couldn't be minted — rotate gateway token |
 | `Secrets not configured` | `POST /v0/secrets` (`503`) | Server-side encryption key not provisioned — contact support |
 | `Duplicate secret name` | `POST /v0/secrets` (`409`) | Secret name is already taken |
 | `Conflicting secrets` | `POST /v0/agents/{agentId}/secrets` (`409`) | Attaching two creds for the same provider (e.g. API key + subscription) |
 | `Invalid parameters` | Tasks create (`400`) | One of `name`, `schedule`, or `payload` is missing or malformed |
-| `Failed to create cron job` | Tasks create (`500`) | OpenClaw rejected the cron config |
-| `Failed to list cron jobs` | Tasks list (`500`) | OpenClaw CLI failed |
+| `Failed to create cron job` | Tasks create (`500`) | Engine rejected the cron config |
+| `Failed to list cron jobs` | Tasks list (`500`) | Engine CLI failed |
 
 ## See also
 

--- a/agents/logs.mdx
+++ b/agents/logs.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Logs"
-description: "Stream OpenClaw's output in real time"
+description: "Stream your agent engine's output in real time"
 icon: "scroll"
 ---
 
-The Logs tab is a live stream of what OpenClaw is doing inside your agent. New entries appear without refreshing — the tab uses a WebSocket under the hood. If the small status badge in the header reads `WEBSOCKET CONNECTED`, you're streaming. If it reads `WEBSOCKET NOT CONNECTED`, either the agent isn't running or the connection dropped — hit the refresh button or check the agent's status.
+The Logs tab is a live stream of what the agent engine is doing inside your agent. New entries appear without refreshing — the tab uses a WebSocket under the hood. If the small status badge in the header reads **Connected**, you're streaming. If it reads **WebSocket not connected**, either the agent isn't running, the connection dropped, or there are no gateway log lines yet — hit the refresh button or check the agent's status.
 
 <Frame>
   ![Image](/images/image-38.png)
@@ -35,14 +35,14 @@ The **AUTO-FOLLOW** checkbox keeps the view pinned to the latest entry. Uncheck 
 
 ## Where the logs live on disk
 
-Inside the container, OpenClaw writes daily log files to `/tmp/openclaw/openclaw-{date}.log`. From the [Console](/agents/console):
+Inside an OpenClaw container, daily log files live at `/tmp/openclaw/openclaw-{date}.log`. From the [Console](/agents/console):
 
 ```bash
 ls /tmp/openclaw/
 tail -f /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log
 ```
 
-That's identical to what the Logs tab streams, with one difference: only the last 100 lines are retained when the gateway restarts. If you need long-term retention, export periodically.
+For other engines, use the Logs tab or the logs API as the stable interface; on-disk log paths are engine-specific. The API keeps the latest 100 lines when the gateway restarts. If you need long-term retention, export periodically.
 
 ## Reading logs over the API
 

--- a/agents/manifest.mdx
+++ b/agents/manifest.mdx
@@ -226,7 +226,7 @@ Only used when the manifest is the source for a marketplace template. Ignored fo
 ## Validation
 
 <Note>
-  `manifest.json` is different from `openclaw.json` - see [Concepts → manifest vs openclaw config](/agents/concepts#manifest-json-vs-openclaw-json). The `/v0/agents/{agentId}/config/validate` endpoint validates `openclaw.json`, not `manifest.json`.
+  `manifest.json` is different from engine runtime config - see [Concepts → manifest vs runtime config](/agents/concepts#manifest-json-vs-openclaw-json). The `/v0/agents/{agentId}/config/validate` endpoint validates runtime config, not `manifest.json`.
 </Note>
 
 To validate `manifest.json` ahead of committing, run it through the template validator (which checks `manifest.json` + `README.md` + `workspace/`):

--- a/agents/models.mdx
+++ b/agents/models.mdx
@@ -49,7 +49,9 @@ openrouter/tencent/hy3-preview
 openai/gpt-5.4
 ```
 
-The provider prefix tells the agent engine (OpenClaw or Hermes) which connected provider to use. If you give it a model that isn't enabled on this agent, the request falls back to the default.
+The provider prefix tells the agent engine which connected provider to use. If you give it a model that isn't enabled on this agent, the request falls back to the default.
+
+Provider availability and default enabled models can vary by engine. For example, fresh OpenClaw and Hermes agents can start with different Anthropic defaults.
 
 ## What's available today
 

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -6,7 +6,7 @@ icon: "lobster"
 
 Pinata Agents gives you a hosted AI agent in its own sandboxed container. The agent has a workspace it can read and write to, a terminal it can run commands in, and connectors for the outside world — chat apps, web servers, scheduled jobs. You talk to it through the dashboard, the CLI, or whichever messaging platform you connect it to.
 
-Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, or `hermes` for an opinionated, smoother out-of-the-box experience. You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
+Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, or `hermes` for an opinionated smoother out-of-the-box experience. You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
 
 <Note>
   Agents require a paid Pinata plan. [Upgrade here](https://app.pinata.cloud/billing).
@@ -35,7 +35,7 @@ Head to [My Agents](https://agents.pinata.cloud/agents) and click **Create Agent
 You have two paths:
 
 - **Start from a template** — fastest. Templates come pre-wired with skills, settings, and a personality. Pick one from the [Marketplace](https://agents.pinata.cloud/marketplace) (others' templates) or [My Templates](https://agents.pinata.cloud/templates) (your own). Add the secrets it needs, deploy.
-- **Build from scratch** — full control. The wizard walks you through naming the agent, choosing an **Agent Engine** (OpenClaw or Hermes), picking a personality preset (Atlas, Nova, Sage, or custom), choosing skills, and connecting your LLM provider.
+- **Build from scratch** — full control. The wizard walks you through naming the agent, choosing an **Agent Engine** (OpenClaw, Hermes, or another enabled engine), picking a personality preset, choosing skills, connecting your LLM provider, and optionally configuring channels before deploy.
 
 Either way, the agent takes about 30 seconds to provision. When it's ready you land on its Chat tab.
 

--- a/agents/troubleshooting.mdx
+++ b/agents/troubleshooting.mdx
@@ -10,7 +10,7 @@ Most problems with an agent fall into a small number of buckets, and the answer 
 2. **Danger tab** — the [Danger](/agents/devtools) tab is the inventory page. Check status, last sync, the lifecycle-script state, and whether your secrets show as `Synced`.
 3. **Console** — the [Console](/agents/console) is a shell. `tail /tmp/user-build.log`, `env`, `ps aux` answer about 80% of "why doesn't my service work" questions.
 4. **Files** — if something used to work and broke after a recent change, restore an earlier snapshot from the [Files](/agents/snapshots) tab.
-5. **Validate config** — `POST /v0/templates/validate` checks `manifest.json`; `POST /v0/agents/{agentId}/config/validate` checks the runtime `openclaw.json`. These are two different files, see [Concepts](/agents/concepts#manifest-json-vs-openclaw-json) for the difference.
+5. **Validate config** — `POST /v0/templates/validate` checks `manifest.json`; `POST /v0/agents/{agentId}/config/validate` checks the engine runtime config shown on the Danger tab. These are different files, see [Concepts](/agents/concepts#manifest-json-vs-openclaw-json) for the difference.
 
 If you're staring at an HTTP error code, the [Error reference](/agents/errors) goes status-by-status with the common responses.
 
@@ -38,7 +38,7 @@ curl -H "Authorization: Bearer $PINATA_JWT" \
 | `build` script failed | Fix the script, then **Retry Scripts** on the Danger tab (or `POST /v0/agents/{agentId}/scripts/retry`) |
 | Missing required secret | The Danger page flags missing secrets. Attach in the [Secrets Vault](/agents/secrets), then restart the gateway |
 | Container OOM | A heavy `npm install` or model load can hit the memory ceiling. Slim dependencies or break up the script |
-| Engine version pinned to a broken release | Danger → **Change** to update to latest (works for OpenClaw and Hermes) |
+| Engine version pinned to a broken release | Danger → **Change** to update to latest, when the engine exposes version changes |
 
 ## Gateway won't connect / chat is offline
 
@@ -222,7 +222,7 @@ Switch the agent's model dropdown in chat to see what model is actually being us
 Open a ticket from **Support → Chat with us** in the sidebar, or email `team@pinata.cloud`. Useful info to include:
 
 - Agent ID (Danger → Agent → Agent ID)
-- OpenClaw version
+- Engine and version, if shown on the Danger tab
 - A recent `EXPORT VISIBLE` from the Logs tab (filter to `ERROR` first)
 - The relevant section of `manifest.json` if config-related
 - What you expected vs. what happened

--- a/tools/cli/agents.mdx
+++ b/tools/cli/agents.mdx
@@ -19,7 +19,7 @@ NAME:
    pinata agents - Interact with AI agents on Pinata
 
 USAGE:
-   pinata agents command [command options] [arguments...]
+   pinata agents [command [command options]]
 
 COMMANDS:
    list, l          List all agents
@@ -28,7 +28,7 @@ COMMANDS:
    delete, d        Delete an agent
    restart, r       Restart an agent
    logs             Get agent logs
-   chat             Interactive chat with an agent
+   chat, c          Interactive chat with an agent
    exec             Execute a command in an agent container
    skills, sk       Manage agent skills
    secrets, sec     Manage secrets
@@ -39,14 +39,14 @@ COMMANDS:
    ports, p         Manage agent port forwarding
    domains, dom     Manage custom domains (beta)
    files            Agent file operations
-   templates, tpl   Browse pre-built agent templates
+   templates, tpl   Browse and manage agent templates
    clawhub, hub     Browse and install skills from ClawHub
    config, cfg      Manage agent configuration
    update, up       Manage agent openclaw updates
    versions, ver    List available agent versions
-   auth             Authenticate with AI providers (anthropic, openai, openrouter)
+   engines          List the agent engines enabled for this deployment
+   auth             Authenticate with a provider and store the credential as a secret
    feedback         Submit feedback or feature request
-   help, h          Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -59,7 +59,7 @@ NAME:
    pinata agents list - List all agents
 
 USAGE:
-   pinata agents list [command options] [arguments...]
+   pinata agents list [options]
 
 OPTIONS:
    --help, -h  show help
@@ -72,18 +72,24 @@ NAME:
    pinata agents create - Create a new agent
 
 USAGE:
-   pinata agents create [command options] [arguments...]
+   pinata agents create [options]
 
 OPTIONS:
-   --name value, -n value             Name of the agent (required)
-   --description value, -d value      Agent personality description
-   --vibe value                       Agent vibe/tagline
-   --emoji value                      Agent emoji
-   --skill value [ --skill value ]    Skill CIDs to attach (can be specified multiple times)
-   --secret value [ --secret value ]  Secret IDs to attach (can be specified multiple times)
-   --template value, -t value         Template ID to deploy from (uses template snapshot, skills, and defaults)
-   --help, -h                         show help
+   --name string, -n string             Name of the agent (required)
+   --description string, -d string      Agent personality description
+   --vibe string                        Agent vibe/tagline
+   --emoji string                       Agent emoji
+   --engine string                      Container engine: openclaw (default) or hermes
+   --skill string [ --skill string ]    Skill CIDs to attach (can be specified multiple times)
+   --secret string [ --secret string ]  Secret IDs to attach (can be specified multiple times)
+   --template string, -t string         Template ID to deploy from (uses template snapshot, skills, and defaults)
+   --user-name string                   Owner display name (written into workspace/USER.md)
+   --user-email string                  Owner email (written into workspace/USER.md)
+   --channels string                    Channel config as JSON (for Hermes agents; set at creation to avoid a restart), e.g. '{"telegram":{"botToken":"...","dmPolicy":"open"}}'
+   --help, -h                           show help
 ```
+
+`--engine` selects the container engine. It defaults to `openclaw` server-side; pass `hermes` for the opinionated engine. Run [`pinata agents engines`](#engines) to see which engines your deployment allows. See [Concepts → Engine](/agents/concepts#engine) for the differences.
 
 **Example with template:**
 
@@ -95,23 +101,124 @@ pinata agents templates list
 pinata agents create --name "My IPFS Agent" --template tpchchgg
 ```
 
+**Example with a Hermes engine and channels:**
+
+Pass `--channels` as a JSON object to configure Telegram, Slack, or Discord at creation for engines that support create-time channel bootstrap. This is especially useful for Hermes agents because the channel can come up with the agent and avoid a post-create restart. The per-channel fields (`botToken`, `appToken`, `dmPolicy`, `allowFrom`) match the [Channels API](/agents/api#channels) and the [`channels` block in `manifest.json`](/agents/manifest#channels).
+
+```bash
+# Create a Hermes agent
+pinata agents create --name "My Hermes Agent" --engine hermes
+
+# Create a Hermes agent with Telegram configured at creation
+pinata agents create \
+  --name "My Hermes Agent" \
+  --engine hermes \
+  --user-name "Ada Lovelace" \
+  --user-email "ada@example.com" \
+  --channels '{"telegram":{"botToken":"123:abc","dmPolicy":"open"}}'
+```
+
+## `get`
+
+```
+NAME:
+   pinata agents get - Get agent details
+
+USAGE:
+   pinata agents get [options] [agent ID]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+The response includes the agent's `engine` so you can tell OpenClaw, Hermes, and other enabled engines apart.
+
+## `delete`
+
+```
+NAME:
+   pinata agents delete - Delete an agent
+
+USAGE:
+   pinata agents delete [options] [agent ID]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+## `restart`
+
+```
+NAME:
+   pinata agents restart - Restart an agent
+
+USAGE:
+   pinata agents restart [options] [agent ID]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+## `logs`
+
+```
+NAME:
+   pinata agents logs - Get agent logs
+
+USAGE:
+   pinata agents logs [options] [agent ID]
+
+OPTIONS:
+   --help, -h  show help
+```
+
 ## `chat`
 
-Start an interactive chat session with an agent. Supports multiple output modes for different use cases.
+Start an interactive chat session with an agent. Supports multiple output modes for different use cases, and works across supported agent engines.
 
 ```
 NAME:
    pinata agents chat - Interactive chat with an agent
 
 USAGE:
-   pinata agents chat [command options] [agent ID] [optional prompt]
+   pinata agents chat [options] [agent ID] [optional prompt]
+
+DESCRIPTION:
+   Start an interactive chat session with an agent.
+
+   The gateway URL and token are automatically fetched from the agent's configuration.
+
+   Output modes:
+     - TTY stdout:     Interactive TUI with markdown rendering
+     - Non-TTY stdout: JSONL streaming (machine-readable, default for pipes)
+     - --text:         Plain text streaming (simpler alternative to JSONL)
+     - --conversation: Multi-turn mode (read messages from stdin line-by-line)
+
+   Examples:
+     # Interactive TUI mode
+     pinata agents chat <agent-id>
+
+     # Single message with plain text response (for agents/scripts)
+     echo "Hello" | pinata agents chat <agent-id> --text
+
+     # JSONL output (machine-readable, default when piped)
+     echo "Hello" | pinata agents chat <agent-id>
+
+     # Multi-turn conversation (each line is a message)
+     echo -e "Hello\nHow are you?" | pinata agents chat <id> -C --text
+
+     # Interactive conversation from a file
+     pinata agents chat <id> --conversation --text < messages.txt
+
+     # Filter JSONL with jq
+     echo "hi" | pinata agents chat <id> | jq -c 'select(.type=="content_delta")'
 
 OPTIONS:
-   --model value       Model override
+   --model string      Model override
    --json              Force JSONL output (auto-enabled when stdout is not a TTY)
    --text              Force plain text output (simpler alternative to JSONL for pipes)
    --conversation, -C  Multi-turn conversation mode (read messages from stdin line-by-line)
-   --session value     Session key for conversation context
+   --session string    Session key for conversation context (default: agent:main:cli)
    --help, -h          show help
 ```
 
@@ -152,11 +259,11 @@ NAME:
    pinata agents exec - Execute a command in an agent container
 
 USAGE:
-   pinata agents exec [command options] [agent ID] [command]
+   pinata agents exec [options] [agent ID] [command]
 
 OPTIONS:
-   --cwd value  Working directory for the command
-   --help, -h   show help
+   --cwd string  Working directory for the command
+   --help, -h    show help
 ```
 
 **Examples:**
@@ -181,11 +288,10 @@ NAME:
    pinata agents files - Agent file operations
 
 USAGE:
-   pinata agents files command [command options] [arguments...]
+   pinata agents files [command [command options]]
 
 COMMANDS:
    read, r  Read a file from agent container
-   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -207,13 +313,12 @@ NAME:
    pinata agents devices - Manage agent devices
 
 USAGE:
-   pinata agents devices command [command options] [arguments...]
+   pinata agents devices [command [command options]]
 
 COMMANDS:
    list, l      List pending and paired devices
    approve, a   Approve a device pairing request
    approve-all  Approve all pending device requests
-   help, h      Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -239,7 +344,7 @@ NAME:
    pinata agents skills - Manage agent skills
 
 USAGE:
-   pinata agents skills command [command options] [arguments...]
+   pinata agents skills [command [command options]]
 
 COMMANDS:
    list, l    List available skills in library
@@ -247,10 +352,37 @@ COMMANDS:
    delete, d  Delete a skill from library
    attach, a  Attach skills to an agent
    detach     Detach a skill from an agent
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
+```
+
+**`create` options:**
+
+```
+OPTIONS:
+   --cid string                     Content ID of the skill (required)
+   --name string, -n string         Skill name (required)
+   --description string, -d string  Skill description
+   --env string [ --env string ]    Required environment variable names
+   --file-id string                 Pinata v3 file ID
+   --help, -h                       show help
+```
+
+**Examples:**
+
+```bash
+# List skills in your library
+pinata agents skills list
+
+# Create a skill from a CID
+pinata agents skills create --cid <skill-cid> --name "My Skill" --env API_KEY
+
+# Attach skills to an agent
+pinata agents skills attach <agent-id> <skill-cid> <skill-cid>
+
+# Detach a skill from an agent
+pinata agents skills detach <agent-id> <skill-id>
 ```
 
 ## `secrets`
@@ -260,7 +392,7 @@ NAME:
    pinata agents secrets - Manage secrets
 
 USAGE:
-   pinata agents secrets command [command options] [arguments...]
+   pinata agents secrets [command [command options]]
 
 COMMANDS:
    list, l    List all secrets
@@ -269,10 +401,31 @@ COMMANDS:
    delete, d  Delete a secret
    attach, a  Attach secrets to an agent
    detach     Detach a secret from an agent
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
+```
+
+**`create` options:**
+
+```
+OPTIONS:
+   --name string, -n string   Secret name (e.g. ANTHROPIC_API_KEY)
+   --value string, -v string  Secret value
+   --help, -h                 show help
+```
+
+**Examples:**
+
+```bash
+# Create a secret
+pinata agents secrets create --name ANTHROPIC_API_KEY --value sk-ant-...
+
+# Update a secret's value
+pinata agents secrets update <secret-id> --value sk-ant-...
+
+# Attach secrets to an agent
+pinata agents secrets attach <agent-id> <secret-id> <secret-id>
 ```
 
 ## `channels`
@@ -282,17 +435,31 @@ NAME:
    pinata agents channels - Manage agent channels
 
 USAGE:
-   pinata agents channels command [command options] [arguments...]
+   pinata agents channels [command [command options]]
 
 COMMANDS:
    status, s     Get channel configuration status
    configure, c  Configure a channel (telegram, slack, discord, whatsapp)
    remove, r     Remove a channel configuration
-   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
 ```
+
+**`configure` options:**
+
+```
+OPTIONS:
+   --bot-token string                           Bot token
+   --app-token string                           App token (Slack only)
+   --dm-policy string                           DM policy: open or pairing
+   --allow-from string [ --allow-from string ]  Allowed user IDs/phone numbers
+   --enabled                                    Enable or disable the channel
+   --skip-restart                               Skip restarting the agent after configuring
+   --help, -h                                   show help
+```
+
+Pass `--skip-restart` to batch multiple channel changes and avoid a gateway restart per call; the new configuration takes effect on the next restart.
 
 **Examples:**
 
@@ -302,6 +469,12 @@ pinata agents channels status <agent-id>
 
 # Configure Telegram
 pinata agents channels configure <agent-id> telegram --bot-token <token>
+
+# Configure a channel without restarting the agent
+pinata agents channels configure <agent-id> telegram --bot-token <token> --skip-restart
+
+# Disable a channel without removing its configuration
+pinata agents channels configure <agent-id> telegram --enabled=false
 
 # Remove a channel
 pinata agents channels remove <agent-id> telegram
@@ -314,14 +487,13 @@ NAME:
    pinata agents snapshots - Manage agent snapshots
 
 USAGE:
-   pinata agents snapshots command [command options] [arguments...]
+   pinata agents snapshots [command [command options]]
 
 COMMANDS:
    list, l    List agent snapshots
    create, c  Create a snapshot
    status, s  Get sync status
    reset, r   Reset to a snapshot
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -350,7 +522,7 @@ NAME:
    pinata agents tasks - Manage agent cron jobs/tasks
 
 USAGE:
-   pinata agents tasks command [command options] [arguments...]
+   pinata agents tasks [command [command options]]
 
 COMMANDS:
    list, l    List tasks
@@ -360,33 +532,108 @@ COMMANDS:
    toggle     Enable or disable a task
    run        Run a task immediately
    history    View task run history
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
 ```
 
-**Creating tasks:**
+### `create`
 
-```bash
-# Create hourly task with system event
-pinata agents tasks create --name "hourly-check" --every 1h --system-event "Check status" <agent-id>
+```
+NAME:
+   pinata agents tasks create - Create a new task
 
-# Create daily task with cron expression
-pinata agents tasks create --name "daily-report" --cron "0 9 * * *" --agent-turn "Generate report" <agent-id>
+USAGE:
+   pinata agents tasks create [options] [agent ID]
 
-# Create one-time task
-pinata agents tasks create --name "scheduled-job" --at "2026-04-01T12:00:00Z" --system-event "Run once" <agent-id>
+DESCRIPTION:
+   Create a new cron job for an agent.
+
+   Schedule types:
+     --at       Run once at a specific time (ISO 8601 format)
+     --every    Run at intervals (e.g., "1h", "30m", "24h")
+     --cron     Run on a cron schedule (e.g., "0 9 * * *")
+
+   Payload types (choose one):
+     --system-event  System event text (triggers heartbeat-style execution)
+     --agent-turn    Agent turn message (triggers conversational response)
+
+   Examples:
+     # Run every hour with a system event
+     pinata agents tasks create <agent-id> --name "hourly-check" --every 1h --system-event "Check for updates"
+
+     # Run daily at 9am UTC with agent turn
+     pinata agents tasks create <agent-id> --name "daily-report" --cron "0 9 * * *" --agent-turn "Generate daily report"
+
+     # Run once at a specific time
+     pinata agents tasks create <agent-id> --name "one-time" --at "2026-04-01T12:00:00Z" --system-event "Do task"
+
+OPTIONS:
+   --name string, -n string           Task name (required)
+   --description string               Task description
+   --disabled                         Create task in disabled state
+   --at string                        Run once at this time (ISO 8601)
+   --every string                     Run every interval (e.g., 1h, 30m)
+   --cron string                      Cron expression (e.g., '0 9 * * *')
+   --tz string                        Timezone for cron schedule
+   --system-event string              System event payload text
+   --agent-turn string                Agent turn message
+   --model string                     Model override for agent turn
+   --timeout int                      Timeout in seconds (default: 0)
+   --session string                   Session target: main or isolated (default: "main")
+   --skill string [ --skill string ]  Skill CIDs to make available to the task (can be specified multiple times)
+   --help, -h                         show help
 ```
 
-**Schedule types:**
-- `--every` - Interval (e.g., "1h", "30m", "24h")
-- `--cron` - Cron expression (e.g., "0 9 * * *")
-- `--at` - One-time at ISO 8601 timestamp
+### `update`
 
-**Payload types:**
-- `--system-event` - Triggers heartbeat-style execution
-- `--agent-turn` - Triggers conversational response
+```
+NAME:
+   pinata agents tasks update - Update an existing task
+
+USAGE:
+   pinata agents tasks update [options] [agent ID] [job ID]
+
+DESCRIPTION:
+   Update an existing cron job. Only specified fields are changed.
+
+   Examples:
+     # Change task name
+     pinata agents tasks update <agent-id> <job-id> --name "new-name"
+
+     # Update schedule to run every 2 hours
+     pinata agents tasks update <agent-id> <job-id> --every 2h
+
+     # Update payload message
+     pinata agents tasks update <agent-id> <job-id> --system-event "New message"
+
+OPTIONS:
+   --name string, -n string           New task name
+   --description string               New task description
+   --at string                        Run once at this time (ISO 8601)
+   --every string                     Run every interval (e.g., 1h, 30m)
+   --cron string                      Cron expression (e.g., '0 9 * * *')
+   --tz string                        Timezone for cron schedule
+   --system-event string              System event payload text
+   --agent-turn string                Agent turn message
+   --model string                     Model override for agent turn
+   --timeout int                      Timeout in seconds (default: 0)
+   --skill string [ --skill string ]  Skill CIDs to make available to the task (can be specified multiple times)
+   --help, -h                         show help
+```
+
+**Scoping skills to a task:**
+
+`create` and `update` accept `--skill` (repeatable) to make specific skill CIDs available only while the task runs:
+
+```bash
+# Create a task with task-scoped skills
+pinata agents tasks create --name "nightly-report" --cron "0 0 * * *" \
+  --agent-turn "Summarize today" --skill <skill-cid> --skill <skill-cid> <agent-id>
+
+# Add or change task-scoped skills on an existing task
+pinata agents tasks update <agent-id> <task-id> --skill <skill-cid>
+```
 
 ## `templates`
 
@@ -397,7 +644,7 @@ NAME:
    pinata agents templates - Browse and manage agent templates
 
 USAGE:
-   pinata agents templates command [command options] [arguments...]
+   pinata agents templates [command [command options]]
 
 COMMANDS:
    list, l      List available templates
@@ -408,7 +655,8 @@ COMMANDS:
    update, u    Update an existing template submission (re-pull from repo)
    delete, d    Archive a template submission
    branches     List branches for a git repository
-   help, h      Shows a list of commands or help for one command
+   refs         List branches and tags (with the default branch) for a git repository
+   search-refs  Search branches and tags by name for a git repository
 
 OPTIONS:
    --help, -h  show help
@@ -434,21 +682,50 @@ pinata agents templates get ipfs-expert
 
 Your git repo must contain a valid `manifest.json`, a `README.md`, and a `workspace/` directory. See [Creating Templates](/agents/templates#creating-templates) for the full specification.
 
+`submit`, `update`, and `validate` share the `--ref` and `--path` flags:
+
+```
+OPTIONS:
+   --ref string, -r string, --branch string, -b string  Git ref to submit from (e.g. refs/heads/main, refs/tags/v1.0.0, or a bare branch name; default: main)
+   --path string, -p string                             Subdirectory within the repo to use as the template root (for monorepos)
+   --name string                                        Override the template name from manifest.json
+   --slug string                                        Override the template slug from manifest.json (lowercase, hyphens only)
+   --help, -h                                           show help
+```
+
+<Note>
+`--branch`/`-b` are kept as aliases for `--ref`. You can pass a full ref (`refs/heads/main`, `refs/tags/v1.0.0`) or a bare branch name. Use `--path` to point at a subdirectory when your template lives inside a monorepo. `--name`/`--slug` are available on `submit` and `update` only.
+</Note>
+
 ```bash
 # Validate your repo before submitting
 pinata agents templates validate https://github.com/user/my-agent-template
 
-# Validate a specific branch
-pinata agents templates validate https://github.com/user/my-agent-template --branch develop
+# Validate a specific ref (branch or tag)
+pinata agents templates validate https://github.com/user/my-agent-template --ref refs/tags/v1.0.0
 
-# List available branches
-pinata agents templates branches https://github.com/user/my-agent-template
+# Validate a template that lives in a subdirectory (monorepo)
+pinata agents templates validate https://github.com/user/monorepo --path packages/my-agent
 
 # Submit the template
 pinata agents templates submit https://github.com/user/my-agent-template
 
-# Submit from a specific branch
-pinata agents templates submit https://github.com/user/my-agent-template --branch develop
+# Submit from a specific branch with name/slug overrides
+pinata agents templates submit https://github.com/user/my-agent-template \
+  --ref develop --name "My Agent" --slug my-agent
+```
+
+**Discovering refs:**
+
+```bash
+# List branches for a repo
+pinata agents templates branches https://github.com/user/my-agent-template
+
+# List branches and tags (with the default branch)
+pinata agents templates refs https://github.com/user/my-agent-template
+
+# Search branches and tags by name
+pinata agents templates search-refs https://github.com/user/my-agent-template v1
 ```
 
 **Managing your submissions:**
@@ -460,8 +737,8 @@ pinata agents templates mine
 # Update an existing submission (re-pull from repo)
 pinata agents templates update <template-id>
 
-# Update with a new repo URL or branch
-pinata agents templates update <template-id> --git-url https://github.com/user/new-repo --branch main
+# Update with a new repo URL or ref
+pinata agents templates update <template-id> --git-url https://github.com/user/new-repo --ref main
 
 # Archive a submission
 pinata agents templates delete <template-id>
@@ -476,16 +753,26 @@ NAME:
    pinata agents clawhub - Browse and install skills from ClawHub
 
 USAGE:
-   pinata agents clawhub command [command options] [arguments...]
+   pinata agents clawhub [command [command options]]
 
 COMMANDS:
-   list, l     List ClawHub skills
-   get, g      Get skill details
+   list, l     Browse ClawHub skills
+   get, g      Get ClawHub skill details by slug
    install, i  Install a ClawHub skill to your library
-   help, h     Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
+```
+
+**`list` options:**
+
+```
+OPTIONS:
+   --category string, -c string  Filter by category
+   --sort string, -s string      Sort by: popular, newest, name
+   --featured                    Show only featured skills
+   --cursor string               Pagination cursor
+   --help, -h                    show help
 ```
 
 **Examples:**
@@ -494,7 +781,10 @@ OPTIONS:
 # Browse available skills
 pinata agents clawhub list
 
-# Get skill details
+# Browse featured skills, newest first
+pinata agents clawhub list --featured --sort newest
+
+# Get skill details by slug
 pinata agents clawhub get clawdhub
 
 # Install a skill to your library
@@ -510,17 +800,39 @@ NAME:
    pinata agents domains - Manage custom domains (beta)
 
 USAGE:
-   pinata agents domains command [command options] [arguments...]
+   pinata agents domains [command [command options]]
 
 COMMANDS:
    list, l    List custom domains
    add, a     Register a custom domain
    update, u  Update a custom domain
    delete, d  Remove a custom domain
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
+```
+
+**`add` options:**
+
+```
+OPTIONS:
+   --subdomain string  Subdomain name (e.g., 'myapp' for myapp.apps.pinata.cloud)
+   --domain string     Custom domain (e.g., 'api.example.com')
+   --port int          Target container port
+   --protected         Require authentication
+   --help, -h          show help
+```
+
+**`update` options:**
+
+```
+OPTIONS:
+   --subdomain string  New subdomain name
+   --domain string     New custom domain
+   --port int          New target port (default: 0)
+   --protected         Enable authentication
+   --no-protected      Disable authentication
+   --help, -h          show help
 ```
 
 **Examples:**
@@ -535,8 +847,11 @@ pinata agents domains add <agent-id> --subdomain myapp --port 8080
 # Add a custom domain
 pinata agents domains add <agent-id> --domain api.example.com --port 3000 --protected
 
-# Update domain
+# Update domain port
 pinata agents domains update <agent-id> <domain-id> --port 8081
+
+# Disable authentication on a domain
+pinata agents domains update <agent-id> <domain-id> --no-protected
 
 # Remove domain
 pinata agents domains delete <agent-id> <domain-id>
@@ -551,12 +866,11 @@ NAME:
    pinata agents ports - Manage agent port forwarding
 
 USAGE:
-   pinata agents ports command [command options] [arguments...]
+   pinata agents ports [command [command options]]
 
 COMMANDS:
    list, l  List port forwarding rules
    set, s   Set port forwarding rules
-   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -568,8 +882,11 @@ OPTIONS:
 # List current port mappings
 pinata agents ports list <agent-id>
 
-# Set port forwarding (port:pathPrefix format)
+# Set port forwarding (port:pathPrefix format, up to 10 rules)
 pinata agents ports set <agent-id> 8080:/api 3000:/app
+
+# Clear all port forwarding rules
+pinata agents ports set <agent-id>
 ```
 
 ## `config`
@@ -581,13 +898,12 @@ NAME:
    pinata agents config - Manage agent configuration
 
 USAGE:
-   pinata agents config command [command options] [arguments...]
+   pinata agents config [command [command options]]
 
 COMMANDS:
-   get, g       Read openclaw config
-   set, s       Write openclaw config
-   validate, v  Validate openclaw config
-   help, h      Shows a list of commands or help for one command
+   get, g       Get agent openclaw config
+   set, s       Set agent openclaw config (JSON)
+   validate, v  Validate agent openclaw config
 
 OPTIONS:
    --help, -h  show help
@@ -615,15 +931,22 @@ NAME:
    pinata agents update - Manage agent openclaw updates
 
 USAGE:
-   pinata agents update command [command options] [arguments...]
+   pinata agents update [command [command options]]
 
 COMMANDS:
    check, c  Check for openclaw updates
    apply, a  Apply openclaw update
-   help, h   Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
+```
+
+**`apply` options:**
+
+```
+OPTIONS:
+   --tag string  Specific version or tag to install (e.g., 'latest', '0.3.0', 'beta')
+   --help, -h    show help
 ```
 
 **Examples:**
@@ -648,7 +971,7 @@ NAME:
    pinata agents versions - List available agent versions
 
 USAGE:
-   pinata agents versions [agent ID]
+   pinata agents versions [options] [agent ID]
 
 OPTIONS:
    --help, -h  show help
@@ -660,6 +983,38 @@ OPTIONS:
 pinata agents versions <agent-id>
 ```
 
+For agents on an engine that publishes versions per engine (such as Hermes), the output includes `availableVersionsPerEngine` (grouped by `openclaw`/`hermes`) alongside the agent's current `engine` and version.
+
+## `engines`
+
+List the agent engines enabled for the current deployment. Use this to discover which values are valid for `agents create --engine`.
+
+```
+NAME:
+   pinata agents engines - List the agent engines enabled for this deployment
+
+USAGE:
+   pinata agents engines [options]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+**Example:**
+
+```bash
+pinata agents engines
+```
+
+Returns the enabled engines, each with an `id` (the value you pass to `--engine`) and a human-readable `label`:
+
+```json
+[
+  { "id": "openclaw", "label": "OpenClaw" },
+  { "id": "hermes", "label": "Hermes" }
+]
+```
+
 ## `auth`
 
 Authenticate with AI providers and store credentials as secrets for your agents.
@@ -669,11 +1024,11 @@ NAME:
    pinata agents auth - Authenticate with a provider and store the credential as a secret
 
 USAGE:
-   pinata agents auth [command options] [provider: anthropic, openai, openrouter]
+   pinata agents auth [options] [provider: anthropic, openai, openrouter, venice]
 
 OPTIONS:
-   --oauth        Use OAuth browser flow instead of API key (openai only)
-   --help, -h     show help
+   --oauth     Use OAuth browser flow instead of API key (openai only)
+   --help, -h  show help
 ```
 
 **Supported Providers:**
@@ -683,6 +1038,7 @@ OPTIONS:
 | `anthropic` | `ANTHROPIC_API_KEY` | - |
 | `openai` | `OPENAI_API_KEY` or `OPENAI_OAUTH_TOKEN` | `--oauth` for Codex OAuth flow |
 | `openrouter` | `OPENROUTER_API_KEY` | - |
+| `venice` | `VENICE_API_KEY` | - |
 
 **Examples:**
 
@@ -698,4 +1054,28 @@ pinata agents auth openai --oauth
 
 # Store OpenRouter API key
 pinata agents auth openrouter
+
+# Store Venice API key
+pinata agents auth venice
+```
+
+## `feedback`
+
+Submit feedback or a feature request from the terminal.
+
+```
+NAME:
+   pinata agents feedback - Submit feedback or feature request
+
+USAGE:
+   pinata agents feedback [options] [message]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+**Example:**
+
+```bash
+pinata agents feedback "It would be great to..."
 ```

--- a/tools/cli/ipfs.mdx
+++ b/tools/cli/ipfs.mdx
@@ -13,14 +13,14 @@ NAME:
    pinata upload - Upload a file to Pinata
 
 USAGE:
-   pinata upload [command options] [path to file]
+   pinata upload [options] [path to file]
 
 OPTIONS:
-   --group value, -g value  Upload a file to a specific group by passing in the groupId
-   --name value, -n value   Add a name for the file you are uploading. By default it will use the filename on your system. (default: "nil")
-   --verbose                Show upload progress (default: false)
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h               show help
+   --group string, -g string       Upload a file to a specific group by passing in the groupId
+   --name string, -n string        Add a name for the file you are uploading. By default it will use the filename on your system. (default: "nil")
+   --verbose                        Show upload progress
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                       show help
 ```
 
 ## `files`
@@ -30,14 +30,13 @@ NAME:
    pinata files - Interact with your files on Pinata
 
 USAGE:
-   pinata files command [command options] [arguments...]
+   pinata files [command [command options]]
 
 COMMANDS:
    delete, d  Delete a file by ID
    get, g     Get file info by ID
    update, u  Update a file by ID
    list, l    List most recent files
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -50,11 +49,11 @@ NAME:
    pinata files get - Get file info by ID
 
 USAGE:
-   pinata files get [command options] [ID of file]
+   pinata files get [options] [ID of file]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `list`
@@ -64,19 +63,19 @@ NAME:
    pinata files list - List most recent files
 
 USAGE:
-   pinata files list [command options] [arguments...]
+   pinata files list [options]
 
 OPTIONS:
-   --name value, -n value                                           Filter by name of the target file
-   --cid value, -c value                                            Filter results by CID
-   --group value, -g value                                          Filter results by group ID
-   --mime value, -m value                                           Filter results by file mime type
-   --amount value, -a value                                         The number of files you would like to return
-   --token value, -t value                                          Paginate through file results using the pageToken
-   --cidPending                                                     Filter results based on whether or not the CID is pending (default: false)
-   --keyvalues value, --kv value [ --keyvalues value, --kv value ]  Filter results by metadata keyvalues (format: key=value)
-   --network value, --net value                                     Specify the network (public or private). Uses default if not specified
-   --help, -h                                                       show help
+   --name string, -n string                                             Filter by name of the target file
+   --cid string, -c string                                              Filter results by CID
+   --group string, -g string                                            Filter results by group ID
+   --mime string, -m string                                             Filter results by file mime type
+   --amount string, -a string                                           The number of files you would like to return
+   --token string, -t string                                            Paginate through file results using the pageToken
+   --cidPending                                                         Filter results based on whether or not the CID is pending
+   --keyvalues string, --kv string [ --keyvalues string, --kv string ]  Filter results by metadata keyvalues (format: key=value)
+   --network string, --net string                                       Specify the network (public or private). Uses default if not specified
+   --help, -h                                                           show help
 ```
 
 ### `update`
@@ -86,12 +85,12 @@ NAME:
    pinata files update - Update a file by ID
 
 USAGE:
-   pinata files update [command options] [ID of file]
+   pinata files update [options] [ID of file]
 
 OPTIONS:
-   --name value, -n value        Update the name of a file
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --name string, -n string        Update the name of a file
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `delete`
@@ -101,11 +100,11 @@ NAME:
    pinata files delete - Delete a file by ID
 
 USAGE:
-   pinata files delete [command options] [ID of file]
+   pinata files delete [options] [ID of file]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ## `groups`
@@ -115,7 +114,7 @@ NAME:
    pinata groups - Interact with file groups
 
 USAGE:
-   pinata groups command [command options] [arguments...]
+   pinata groups [command [command options]]
 
 COMMANDS:
    create, c  Create a new group
@@ -125,7 +124,6 @@ COMMANDS:
    get, g     Get group info by ID
    add, a     Add a file to a group
    remove, r  Remove a file from a group
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -138,11 +136,11 @@ NAME:
    pinata groups create - Create a new group
 
 USAGE:
-   pinata groups create [command options] [name of group]
+   pinata groups create [options] [name of group]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `get`
@@ -152,11 +150,11 @@ NAME:
    pinata groups get - Get group info by ID
 
 USAGE:
-   pinata groups get [command options] [ID of group]
+   pinata groups get [options] [ID of group]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `list`
@@ -166,14 +164,29 @@ NAME:
    pinata groups list - List groups on your account
 
 USAGE:
-   pinata groups list [command options] [arguments...]
+   pinata groups list [options]
 
 OPTIONS:
-   --amount value, -a value      The number of groups you would like to return (default: "10")
-   --name value, -n value        Filter groups by name
-   --token value, -t value       Paginate through results using the pageToken
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --amount string, -a string      The number of groups you would like to return (default: "10")
+   --name string, -n string        Filter groups by name
+   --token string, -t string       Paginate through results using the pageToken
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
+```
+
+### `update`
+
+```
+NAME:
+   pinata groups update - Update a group
+
+USAGE:
+   pinata groups update [options] [ID of group]
+
+OPTIONS:
+   --name string, -n string        Update the name of a group
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `add`
@@ -183,11 +196,11 @@ NAME:
    pinata groups add - Add a file to a group
 
 USAGE:
-   pinata groups add [command options] [group id] [file id]
+   pinata groups add [options] [group id] [file id]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `remove`
@@ -197,11 +210,11 @@ NAME:
    pinata groups remove - Remove a file from a group
 
 USAGE:
-   pinata groups remove [command options] [group id] [file id]
+   pinata groups remove [options] [group id] [file id]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ## `gateways`
@@ -211,13 +224,12 @@ NAME:
    pinata gateways - Interact with your gateways on Pinata
 
 USAGE:
-   pinata gateways command [command options] [arguments...]
+   pinata gateways [command [command options]]
 
 COMMANDS:
    set, s   Set your default gateway to be used by the CLI
    open, o  Open a file in the browser
    link, l  Get either an IPFS link for a public file or a temporary access link for a Private IPFS file
-   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -234,7 +246,7 @@ NAME:
    pinata gateways set - Set your default gateway to be used by the CLI
 
 USAGE:
-   pinata gateways set [command options] [domain of the gateway]
+   pinata gateways set [options] [domain of the gateway]
 
 OPTIONS:
    --help, -h  show help
@@ -247,11 +259,11 @@ NAME:
    pinata gateways link - Get either an IPFS link for a public file or a temporary access link for a Private IPFS file
 
 USAGE:
-   pinata gateways link [command options] [cid of the file, seconds the url is valid for]
+   pinata gateways link [options] [cid of the file, seconds the url is valid for]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `open`
@@ -261,11 +273,11 @@ NAME:
    pinata gateways open - Open a file in the browser
 
 USAGE:
-   pinata gateways open [command options] [CID of the file]
+   pinata gateways open [options] [CID of the file]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ## `keys`
@@ -275,13 +287,12 @@ NAME:
    pinata keys - Create and manage generated API keys
 
 USAGE:
-   pinata keys command [command options] [arguments...]
+   pinata keys [command [command options]]
 
 COMMANDS:
    create, c  Create an API key with admin or scoped permissions
    list, l    List and filter API key
    revoke, r  Revoke an API key
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -294,14 +305,14 @@ NAME:
    pinata keys create - Create an API key with admin or scoped permissions
 
 USAGE:
-   pinata keys create [command options] [arguments...]
+   pinata keys create [options]
 
 OPTIONS:
-   --name value, -n value                                       Name of the API key
-   --admin, -a                                                  Set the key as Admin (default: false)
-   --uses value, -u value                                       Max uses a key can use (default: 0)
-   --endpoints value, -e value [ --endpoints value, -e value ]  Optional array of endpoints the key is allowed to use
-   --help, -h                                                   show help
+   --name string, -n string                                         Name of the API key
+   --admin, -a                                                      Set the key as Admin
+   --uses int, -u int                                               Max uses a key can use (default: 0)
+   --endpoints string, -e string [ --endpoints string, -e string ]  Optional array of endpoints the key is allowed to use
+   --help, -h                                                       show help
 ```
 
 ### `list`
@@ -311,15 +322,15 @@ NAME:
    pinata keys list - List and filter API key
 
 USAGE:
-   pinata keys list [command options] [arguments...]
+   pinata keys list [options]
 
 OPTIONS:
-   --name value, -n value    Name of the API key
-   --revoked, -r             Set the key as Admin (default: false)
-   --exhausted, -e           Filter keys that are exhausted or not (default: false)
-   --uses, -u                Filter keys that do or don't have limited uses (default: false)
-   --offset value, -o value  Offset the number of results to paginate
-   --help, -h                show help
+   --name string, -n string    Name of the API key
+   --revoked, -r               Set the key as Admin
+   --exhausted, -e             Filter keys that are exhausted or not
+   --uses, -u                  Filter keys that do or don't have limited uses
+   --offset string, -o string  Offset the number of results to paginate
+   --help, -h                  show help
 ```
 
 ### `revoke`
@@ -329,7 +340,7 @@ NAME:
    pinata keys revoke - Revoke an API key
 
 USAGE:
-   pinata keys revoke [command options] [key]
+   pinata keys revoke [options] [key]
 
 OPTIONS:
    --help, -h  show help
@@ -342,13 +353,12 @@ NAME:
    pinata swaps - Interact and manage hot swaps on Pinata
 
 USAGE:
-   pinata swaps command [command options] [arguments...]
+   pinata swaps [command [command options]]
 
 COMMANDS:
    list, l    List swaps for a given gateway domain or for your config gateway domain
    add, a     Add a swap for a CID
    delete, d  Remeove a swap for a CID
-   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -361,11 +371,11 @@ NAME:
    pinata swaps list - List swaps for a given gateway domain or for your config gateway domain
 
 USAGE:
-   pinata swaps list [command options] [cid] [optional gateway domain]
+   pinata swaps list [options] [cid] [optional gateway domain]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `add`
@@ -375,11 +385,11 @@ NAME:
    pinata swaps add - Add a swap for a CID
 
 USAGE:
-   pinata swaps add [command options] [cid] [swap cid]
+   pinata swaps add [options] [cid] [swap cid]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```
 
 ### `delete`
@@ -389,9 +399,9 @@ NAME:
    pinata swaps delete - Remeove a swap for a CID
 
 USAGE:
-   pinata swaps delete [command options] [cid]
+   pinata swaps delete [options] [cid]
 
 OPTIONS:
-   --network value, --net value  Specify the network (public or private). Uses default if not specified
-   --help, -h                    show help
+   --network string, --net string  Specify the network (public or private). Uses default if not specified
+   --help, -h                      show help
 ```

--- a/tools/cli/overview.mdx
+++ b/tools/cli/overview.mdx
@@ -78,11 +78,10 @@ NAME:
    pinata config - Configure Pinata CLI settings
 
 USAGE:
-   pinata config command [command options] [arguments...]
+   pinata config [command [command options]]
 
 COMMANDS:
    network, net  Set default network (public or private)
-   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help


### PR DESCRIPTION
## Summary

Generalizes the agent docs from OpenClaw-only to the OpenClaw/Hermes engine model now exposed by the API, dashboard, and CLI, and brings the CLI reference up to date with the current `ipfs-cli` command surface.

### Agent docs (concepts, api, console, devtools, manifest, models, logs, channels, chat, errors, overview, troubleshooting)
- Describe the `openclaw` and `hermes` engines, including per-engine workspace paths and runtime-config locations (`openclaw.json` vs `/home/hermes/data/config.yaml`)
- Cover engine-specific Danger-tab actions (OpenClaw Settings UI vs the Config row **Edit**), create-time channel bootstrap, and engine-specific chat delivery (token streaming vs whole-message)
- API: add `/v0/agents/engines`, the engine runtime config endpoints, and the `engine`/`channels` create fields

### CLI reference (`tools/cli`)
- Refresh every help block to the urfave/cli **v3** format (`value` → typed `string`/`int`, updated usage lines, dropped `(default: false)`)
- Cover the current command surface: `agents engines`; `--engine` / `--channels` / `--user-name` / `--user-email` on create; templates `refs` / `search-refs` and `--ref` / `--path` / `--name` / `--slug`; Venice auth provider; clawhub / skills / secrets / tasks / channels flags; and the missing `groups update` section

### Notes
- Tracks the in-progress CLI engine support in [PinataCloud/ipfs-cli#12](https://github.com/PinataCloud/ipfs-cli/pull/12).
- Super Builder is intentionally **not** documented (not public-facing), even though the CLI `--help` and `agents engines` may surface it on enabled deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)