### PR TITLE
Document the agents v0.15.1 ship (free tier, Issues & Boards, files explorer)

### DIFF
--- a/agents/chat.mdx
+++ b/agents/chat.mdx
@@ -52,6 +52,15 @@ Use the **MODEL** dropdown in the composer. You can switch between any models yo
 
 If you want to confirm what the agent is currently using without scrolling, send `/status`.
 
+## Chatting while the agent is stopped or restarting
+
+You don't have to wait for a stopped or restarting agent. The composer stays open ("Agent is starting — type a message and it'll send when ready…") and anything you send is queued:
+
+- Each queued message shows a **QUEUED** clock chip, with an **×** to cancel it before it sends
+- A status line tracks the backlog — "3 messages queued · sending when the agent finishes starting…"
+- Queued messages **survive a page reload** — refresh or navigate away mid-restart and they're still waiting when you come back
+- The moment the agent is back online, messages deliver automatically, **in order, one at a time** — no duplicates, and the agent answers each one individually
+
 ## More room for the conversation
 
 Click **Hide navbar** in the top-right corner to collapse the left sidebar — the conversation gets the full width of the screen. Click it again to bring the sidebar back.
@@ -59,7 +68,7 @@ Click **Hide navbar** in the top-right corner to collapse the left sidebar — t
 ## Tips
 
 - Long-running tool calls show a progress indicator. Wait for it before assuming the agent is stuck.
-- If the chat looks disconnected and stays that way, the gateway probably needs a kick. Open **Danger** → **Restart Gateway**.
-- If you change a secret, attach a new skill, or add a channel, restart the gateway so the agent picks up the change.
+- If the chat looks disconnected and stays that way, the gateway probably needs a kick. Open **Danger** → **Restart Gateway**. Messages you send during the restart queue up and deliver when it's back.
+- If you change a secret, attach a new skill, or add a channel, restart the gateway so the agent picks up the change. Attaching a new LLM provider restarts the agent with a fresh environment automatically.
 
 For deeper debugging, the [Logs](/agents/logs) tab streams what the agent engine is doing under the hood. See [Troubleshooting](/agents/troubleshooting) for common failure modes.

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -35,6 +35,7 @@ The runtime that powers the agent. Engines are enabled per deployment:
 | --- | --- | --- |
 | `openclaw` (default) | Configurable agent for custom workflows and power users | You want full control over manifest fields, scripts, routes, and skills |
 | `hermes` | Opinionated agent with a smoother out-of-the-box experience | You want fewer knobs and first-run channel setup to feel more direct |
+| `super-builder` (beta) | Headless coding agent optimized for issue-board work | You're assigning work through [Issues & Boards](/agents/issues) and want longer runs (200-turn default cap) over chat features. Chat-first surfaces like Channels aren't available. |
 
 Pick the engine when creating the agent — either in the **Agent Engine** card on the Create Agent wizard, or by passing `engine` in `POST /v0/agents`, or by setting `engine` in [`manifest.json`](/agents/manifest) for a template. Available engines per deployment are listed at `GET /v0/agents/engines`.
 
@@ -153,7 +154,7 @@ A pre-configured agent (manifest + workspace files + skill list) packaged for on
 
 ### Issue
 
-(Closed beta, `@pinata.cloud` accounts only.) Kanban-style work item assigned to an agent - title + prompt + optional repo. The agent runs, you review the workspace diff, then approve or revert.
+Kanban-style work item assigned to an agent - title + prompt + optional repo. The agent runs it in an isolated `<workspace>/runs/<runId>/` directory (its own git history; ignored by snapshots), you review the diff, then accept, revise, or open a PR. Boards carry per-board instructions, model overrides, and turn/cost caps. See [Issues & Boards](/agents/issues).
 
 ## Filesystem reference
 
@@ -166,6 +167,7 @@ Paths agents and developers reach for most often inside the container:
 | `/home/hermes/data/workspace/` | Hermes workspace |
 | `<workspace>/skills/<name>/` | Attached skill files |
 | `<workspace>/uploads/` | Uploaded files |
+| `<workspace>/runs/<runId>/` | Isolated working dir for each [issue](/agents/issues) run (gitignored, excluded from snapshots) |
 | `/home/node/.openclaw/openclaw.json` | OpenClaw runtime config |
 | `/home/hermes/data/config.yaml` | Hermes runtime config |
 | `/tmp/openclaw/openclaw-YYYY-MM-DD.log` | Daily OpenClaw log file |

--- a/agents/issues.mdx
+++ b/agents/issues.mdx
@@ -1,0 +1,101 @@
+---
+title: "Issues & Boards"
+sidebarTitle: "Issues"
+description: "Assign work to agents on a kanban board, review the diff, ship it"
+icon: "table-columns"
+---
+
+**My Issues** is a kanban board for handing work to your agents. You file an issue — a title plus a prompt — assign it to an agent, and the agent runs it in an isolated copy of its workspace. When it finishes, the card lands in Review with a full diff for you to accept, revise, or turn into a pull request.
+
+Open **My Issues** in the sidebar. Each workspace can have multiple boards — the **+** next to the board name creates another one.
+
+## The board
+
+Four columns plus an archive:
+
+| Column | What's in it |
+| --- | --- |
+| **Backlog** | Drafted or unassigned issues. This is where new issues start. |
+| **In Progress** | Queued or running. Dragging a backlog card here kicks off the run. |
+| **Review** | Finished runs waiting on you. Check the diff and decide. |
+| **Done** | Accepted work. |
+
+The **Archive** strip at the bottom takes backlog or review cards you're finished with. Cards can also be reordered within a column — ordering is scoped per board.
+
+Above the columns: search, sort, and filters for priority, agent, owner, and tags.
+
+## File an issue
+
+Click **New Issue**. The composer asks for:
+
+- **Who does the work** — **An Agent** (hand the prompt to an agent and review the result) or **I'll do it myself** (no agent; the card just tracks work as you drag it across the board).
+- **Title and prompt** — the prompt is what the agent actually receives. Markdown supported, attachments and checklists too.
+- **Assign** — the agent, an optional **repository**, and tags. Owner, reviewer, priority, and due date live on the card after creation.
+
+Issues start in Backlog. **Start issue** (or dragging the card to In Progress) queues it; the agent picks it up as soon as a slot frees up.
+
+## How a run works
+
+Each run executes in an isolated directory inside the agent's workspace — `<workspace>/runs/<runId>/` — with its own git history, so concurrent runs don't trample each other and the agent's main workspace stays clean. A `.gitignore` entry for `/runs` is added automatically so run directories stay out of workspace snapshots.
+
+While the run is going, the card and the issue drawer both update live:
+
+- The drawer hero shows elapsed time and a **live token count**
+- The conversation pane streams the agent's tool calls and output token count as they happen
+- **Files Changed** renders the diff in real time — you can watch the work land
+
+When the agent finishes it marks the issue **Ready for Review** and the card moves to the Review column on its own.
+
+## Reviewing
+
+Open a Review card. The drawer splits into **Conversation** (the full exchange, including tool calls and the commit the agent made) and **Files Changed** (per-file diffs, unified or split view, expandable to full screen).
+
+From here you can:
+
+- **Accept & Done** — approve the work and mark the issue done. The run's changes stay as-is.
+- **Send revision** — reply with feedback; the agent picks the issue back up and continues in the same run.
+- **Create a PR** — open a pull request from the drawer with a custom title and description (requires a connected repository — see below).
+- **Add comment** — discussion without triggering a run.
+
+## Working against a GitHub repo
+
+Connect GitHub under **Account → Integrations**, then save repositories from the issue composer's repository picker (**Manage repositories**). With a repo attached to an issue:
+
+- **Self-driving issues** spin up a branch and a **draft PR** automatically when the run starts, and the agent continues its work on that branch.
+- **Create PR from the drawer** turns a finished run into a pull request with the title and description you give it.
+- The board tracks PR state — when a PR merges, the card reflects it. GitHub syncing is rate-limit-aware, so large orgs don't get throttled mid-sweep.
+
+## Board settings
+
+Board options (the **⋯** next to the board name) → **Board settings**:
+
+| Setting | What it does | Default |
+| --- | --- | --- |
+| **Instructions** | Markdown prepended to *every* run on this board — coding conventions, commit-message rules, test requirements. Up to 20,000 characters. | empty |
+| **Model override** | Force a specific model for every run on the board. Blank = each agent's own default. | agent default |
+| **Max turns** | Per-run conversation-turn cap (1–1000). The run stops when it hits the limit. | 200 |
+| **Max cost (USD)** | Per-run spend ceiling — the run stops when estimated spend exceeds it. | $25 |
+
+Board instructions are genuinely injected into runs — if your instructions say "prefix commits with `[bot]`", the commits come back prefixed.
+
+## Cost & token tracking
+
+Spend is tracked at three levels:
+
+- **Cards** show the run's cost next to the diffstat (e.g. `$0.13 +5 -0`).
+- **The drawer hero** shows duration and total tokens; hovering it reveals the full **Agent Usage** breakdown — total spend, input/output tokens, and **cached tokens** accounted separately.
+- **The board-level chip** (top right) opens a rollup panel with a **Cost | Tokens** toggle: totals by agent, by model, and a token table splitting input, output, cache reads, and cache writes.
+
+<Note>
+  Live cost during a run is an estimate and can settle to a lower final number once cache pricing is reconciled. Usage reporting depends on the engine — Super Builder runs report the richest data.
+</Note>
+
+## Which engine should issue agents use?
+
+Any agent can take issues, but the **Super Builder** engine exists for exactly this: a headless coding agent optimized for issue-board work, with a higher default turn cap (200) for longer-running jobs. It skips chat-first surfaces like Channels in favor of doing the work and reporting back. See [Concepts → Engine](/agents/concepts#engine).
+
+## Tips
+
+- Use board instructions for anything you'd otherwise paste into every prompt — conventions compound.
+- Set a reviewer on cards that need a second pair of eyes; filter the board by owner when triaging.
+- Run history on a card is ordered by actual run time, so the latest attempt is always what you're reviewing.

--- a/agents/models.mdx
+++ b/agents/models.mdx
@@ -14,6 +14,10 @@ Each agent has its own list of allowed models, grouped by provider. The default 
 
 Open your agent → **Models**. The page lists each connected provider as a separate section. Only providers you've connected in the [Secrets Vault](/agents/secrets) show up here — if you don't see OpenAI, for example, it's because you haven't connected an OpenAI key.
 
+### Free-tier agents
+
+If the agent was created on the **Free tier** (no provider key), the Models page shows a single "Running on Pinata's free tier" state instead of provider sections. The agent uses a free, rate-limited model from OpenRouter's free pool (`openrouter/free`); there's nothing to configure. Add your own provider key in Secrets — the **Add a provider key →** link takes you there — and the full provider/model UI appears for this agent.
+
 Inside each provider section:
 
 - One row per model that's currently enabled
@@ -60,7 +64,10 @@ The exact list updates as providers ship. A current snapshot:
 - **Anthropic** — `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
 - **OpenAI Codex** (subscription) — `gpt-5.4`
 - **OpenRouter** — `auto` (lets OpenRouter pick), plus any specific model on the platform (e.g. `tencent/hy3-preview`)
+- **Free tier** — `openrouter/free` (shared pool, rate-limited, no key needed)
 - **Venice / Pinata / Custom** — whatever the provider exposes
+
+Provider availability also varies by engine — for example, Super Builder agents offer a narrower provider list at creation than OpenClaw agents.
 
 <Tip>
   When you select `auto` on OpenRouter, OpenRouter picks the underlying model for each request. Handy if you don't want to micromanage which model handles what.

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -6,24 +6,21 @@ icon: "lobster"
 
 Pinata Agents gives you a hosted AI agent in its own sandboxed container. The agent has a workspace it can read and write to, a terminal it can run commands in, and connectors for the outside world — chat apps, web servers, scheduled jobs. You talk to it through the dashboard, the CLI, or whichever messaging platform you connect it to.
 
-Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, or `hermes` for an opinionated smoother out-of-the-box experience. You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
-
-<Note>
-  Agents require a paid Pinata plan. [Upgrade here](https://app.pinata.cloud/billing).
-</Note>
+Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, `hermes` for an opinionated smoother out-of-the-box experience, or `super-builder` (beta), a headless coding agent built for [issue-board work](/agents/issues). You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
 
 ## Get your first agent running
 
-It takes a couple of minutes. You'll connect an LLM provider, create the agent, and start chatting.
+It takes a couple of minutes. You'll pick an LLM provider, create the agent, and start chatting.
 
-### 1. Connect an LLM provider
+### 1. Pick an LLM provider
 
-Your agent needs an LLM to think. Go to the [Secrets Vault](https://agents.pinata.cloud/secrets).
+Your agent needs an LLM to think. You have two options:
 
-At the top of that page you'll see a row of provider cards: **Anthropic**, **OpenAI**, **OpenRouter**, **Pinata**, **Venice**, and **Custom**. Click **Connect** on whichever one you use, paste your API key (or run through OAuth if you're using an OpenAI Codex subscription), and save.
+- **Free tier — no key needed.** Select the **Free tier** card in the Create Agent wizard and skip provider setup entirely. Your agent runs on a shared, rate-limited model (OpenRouter's free pool, e.g. `openrouter/free`). Expect lower quality, smaller context, and occasional rate limits compared with a paid provider — but it's a real agent, free, today.
+- **Bring your own key.** Go to the [Secrets Vault](https://agents.pinata.cloud/secrets). At the top of that page you'll see a row of provider cards: **Anthropic**, **OpenAI**, **OpenRouter**, **Pinata**, **Venice**, and **Custom**. Click **Connect** on whichever one you use, paste your API key (or run through OAuth if you're using an OpenAI Codex subscription), and save.
 
 <Tip>
-  Don't have an API key? [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), and [OpenRouter](https://openrouter.ai/) all offer free trial credits.
+  Start free, upgrade whenever — adding a provider key in Secrets later unlocks full model capabilities for the same agent, no re-create needed.
 </Tip>
 
 You can connect more than one provider — useful so you have a fallback if one is down.
@@ -35,9 +32,13 @@ Head to [My Agents](https://agents.pinata.cloud/agents) and click **Create Agent
 You have two paths:
 
 - **Start from a template** — fastest. Templates come pre-wired with skills, settings, and a personality. Pick one from the [Marketplace](https://agents.pinata.cloud/marketplace) (others' templates) or [My Templates](https://agents.pinata.cloud/templates) (your own). Add the secrets it needs, deploy.
-- **Build from scratch** — full control. The wizard walks you through naming the agent, choosing an **Agent Engine** (OpenClaw, Hermes, or another enabled engine), picking a personality preset, choosing skills, connecting your LLM provider, and optionally configuring channels before deploy.
+- **Build from scratch** — full control. The wizard walks you through naming the agent, choosing an **Agent Engine** (OpenClaw, Hermes, or Super Builder), picking an AI provider (including the free tier), a personality preset, skills, and optionally channels before deploy.
 
 Either way, the agent takes about 30 seconds to provision. When it's ready you land on its Chat tab.
+
+<Note>
+  Plans cap how many agents you can run at once. If a deploy fails with "Agent limit reached", delete an agent you're not using or upgrade your plan.
+</Note>
 
 ### 3. Start a conversation
 
@@ -53,8 +54,8 @@ The sidebar on the left is the same on every page. Top half is the workspace its
 
 | Section | What's in it |
 | --- | --- |
-| **My Agents** | Every agent you've created. Click one to expand its tabs (Chat, Channels, Files, Skills, etc.). |
-| **My Issues** | A kanban board for assigning work to agents. Closed beta — `@pinata.cloud` accounts today. |
+| **My Agents** | Every agent you've created. Click one to expand its tabs (Chat, Channels, Files, Skills, etc.). The **ⓘ** on each agent card opens a floating info peek — live status, the default-model picker, skill/secret/task counts, and live CPU, memory, disk, and network meters. |
+| **My Issues** | Kanban boards for assigning work to agents — file an issue, the agent runs it, you review the diff. See [Issues & Boards](/agents/issues). |
 | **Skills Library** | Skills you've installed, plus a community catalog under **Browse ClawHub**. |
 | **Secrets Vault** | All your encrypted credentials, in one place, shared across agents. |
 | **My Templates** | Templates you've created or imported. |
@@ -72,7 +73,7 @@ Click any agent and you'll see tabs across the top of the page. Each tab is a sl
 
 - **Chat** — your conversation with the agent
 - **Channels** — wire it up to Telegram, Slack, or Discord
-- **Files** — workspace snapshot history, content diffs, git URL
+- **Files** — a file browser for the agent's container, workspace snapshot history, content diffs, git URL
 - **Skills** — capabilities attached to this specific agent (pulled from your Skills Library)
 - **Secrets** — provider connections and env vars this agent can see
 - **Models** — which models from your providers it's allowed to use, and which is the default
@@ -130,6 +131,10 @@ Full reference: [Agents CLI](/tools/cli/agents).
 </CardGroup>
 
 <CardGroup cols={2}>
+  <Card title="Issues & Boards" icon="table-columns" href="/agents/issues">
+    Assign work on a kanban board and review the diff
+  </Card>
+
   <Card title="Templates" icon="grid-2" href="/agents/templates/overview">
     Deploy a pre-built agent in one click
   </Card>

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -8,6 +8,10 @@ Pinata Agents gives you a hosted AI agent in its own sandboxed container. The ag
 
 Each agent runs on an **Agent Engine** — `openclaw` (default) for full configurability, `hermes` for an opinionated smoother out-of-the-box experience, or `super-builder` (beta), a headless coding agent built for [issue-board work](/agents/issues). You pick one when you create the agent. The default OpenClaw engine is documented at [openclaw.org](https://openclaw.org); for the differences see [Concepts → Engine](/agents/concepts#engine).
 
+<Note>
+  New accounts get a **10-hour free trial** of agents — no payment and no LLM key required, thanks to the free-tier model available throughout your account. After the trial, agents require a paid plan. [Upgrade here](https://app.pinata.cloud/billing).
+</Note>
+
 ## Get your first agent running
 
 It takes a couple of minutes. You'll pick an LLM provider, create the agent, and start chatting.
@@ -16,7 +20,7 @@ It takes a couple of minutes. You'll pick an LLM provider, create the agent, and
 
 Your agent needs an LLM to think. You have two options:
 
-- **Free tier — no key needed.** Select the **Free tier** card in the Create Agent wizard and skip provider setup entirely. Your agent runs on a shared, rate-limited model (OpenRouter's free pool, e.g. `openrouter/free`). Expect lower quality, smaller context, and occasional rate limits compared with a paid provider — but it's a real agent, free, today.
+- **Free tier — no key, zero config.** Select the **Free tier** card in the Create Agent wizard and skip provider setup entirely. Your agent runs on a shared, rate-limited model (OpenRouter's free pool, e.g. `openrouter/free`) that's available throughout your account. Expect lower quality, smaller context, and occasional rate limits compared with a paid provider — but it's a real agent, free, today.
 - **Bring your own key.** Go to the [Secrets Vault](https://agents.pinata.cloud/secrets). At the top of that page you'll see a row of provider cards: **Anthropic**, **OpenAI**, **OpenRouter**, **Pinata**, **Venice**, and **Custom**. Click **Connect** on whichever one you use, paste your API key (or run through OAuth if you're using an OpenAI Codex subscription), and save.
 
 <Tip>

--- a/agents/secrets.mdx
+++ b/agents/secrets.mdx
@@ -16,7 +16,7 @@ Your agent needs credentials — an LLM key, sometimes a bot token or two, maybe
 
 ## Connect a provider
 
-This is the first thing to do. Without at least one connected provider, your agent has no LLM to call.
+You don't strictly need one — the Create Agent wizard offers a **Free tier** option that runs your agent on a shared, rate-limited model with no key at all. But connecting your own provider unlocks full model quality, context, and rate limits, and it's how a free-tier agent upgrades later.
 
 Open the [Secrets Vault](https://agents.pinata.cloud/secrets). The row at the top — **AI PROVIDERS** — has a card for each supported provider:
 
@@ -28,6 +28,7 @@ Open the [Secrets Vault](https://agents.pinata.cloud/secrets). The row at the to
 | **Pinata** | Pinata-hosted inference |
 | **Venice** | API key (privacy-focused) |
 | **Custom** | Any OpenAI-compatible endpoint |
+| **Free tier** | Nothing — selected in the Create Agent wizard, no key needed |
 
 Cards that aren't connected show a **CONNECT** button. Click it, follow the prompts, save. The card flips to **Connected**.
 

--- a/agents/snapshots.mdx
+++ b/agents/snapshots.mdx
@@ -5,7 +5,7 @@ description: "Browse, version, and edit your agent's workspace"
 icon: "folder-open"
 ---
 
-The Files tab gives you three things: a snapshot history of the agent's workspace, content diffs so you can see what changed between snapshots, and a git URL so you can clone the workspace locally and edit it like any other repo.
+The Files tab gives you four things: a snapshot history of the agent's workspace, content diffs so you can see what changed between snapshots, a file browser for the agent's container, and a git URL so you can clone the workspace locally and edit it like any other repo.
 
 <Frame>
   ![Image](/images/image-39.png)
@@ -51,6 +51,16 @@ curl -X POST \
 ```
 
 The same endpoint with `GET` returns sync status — whether storage is configured, when it last synced, and a human-readable message.
+
+## Workspace Files — browse the container
+
+Below the snapshot list, the **Workspace Files** panel is a live file browser for the agent's pod filesystem — not just the workspace, the whole container.
+
+- **Navigate** — click a folder to enter it, use the breadcrumb or **← Up** to go back, **Workspace** to jump straight to the workspace root, **Refresh** to re-read the current directory
+- **View a file** — click it. Text and markdown files preview inline with size and MIME type; binary files offer a **Download** instead
+- **Upload** — drop files onto the listing or click **Upload** to put files into the current directory
+
+Handy for checking what an agent actually wrote, reading logs in place (e.g. `/home/hermes/data/logs/` on a Hermes agent), or dropping in a config file without opening the [Console](/agents/console).
 
 ## Editing the workspace locally
 

--- a/docs.json
+++ b/docs.json
@@ -68,6 +68,7 @@
                   "agents/overview",
                   "agents/concepts",
                   "agents/chat",
+                  "agents/issues",
                   "agents/secrets",
                   "agents/models",
                   "agents/skills",


### PR DESCRIPTION
Documents the agent platform features shipped Jun 1–3 (releases 0.14.2 → 0.15.1), verified against the live product before writing.

## What's in here

**New page: `agents/issues.mdx`** — Issues & Boards end to end: board columns and lifecycle, the issue composer (agent-driven vs. self-driven cards), run isolation in `runs/<runId>/`, the review drawer, GitHub flows (self-driving branch + draft PR, PR from the drawer, merge detection), board settings (per-board instructions, model override, 200-turn / $25 default caps), and cost & token tracking including cache accounting and the board-level Cost|Tokens rollup.

**Updated pages:**
- `overview.mdx` — free tier as a first-class provider path, 10-hour free trial note, Super Builder engine, agent info peek, Issues de-beta'd, agent plan-limit note
- `concepts.mdx` — `super-builder` in the engine table, expanded Issue glossary entry, `runs/<runId>/` in the filesystem reference
- `models.mdx` — free-tier Models-tab state and upgrade path, free tier in the provider snapshot
- `secrets.mdx` — free tier framing and provider table row
- `chat.mdx` — offline chat queue (queue chips, cancel, reload survival, in-order delivery), fresh env on provider attach
- `snapshots.mdx` — the new Workspace Files browser (navigation, inline viewer, upload)
- `docs.json` — nav entry for the Issues page

🤖 Generated with [Claude Code](https://claude.com/claude-code)